### PR TITLE
fix(core): more contrast to info boxes in dark mode

### DIFF
--- a/libs/website/ui-home/src/lib/introduction.tsx
+++ b/libs/website/ui-home/src/lib/introduction.tsx
@@ -119,7 +119,7 @@ export function Introduction() {
       <section className="-mt-28 max-w-7xl mx-auto relative z-10 pb-32 px-4 sm:px-6 lg:px-8">
         <div className="grid grid-cols-1 gap-y-20 lg:grid-cols-3 lg:gap-y-0 lg:gap-x-8">
           {/*LINKS*/}
-          <div className="flex flex-col bg-slate-50 dark:bg-slate-800 rounded-2xl shadow-xl">
+          <div className="flex flex-col bg-slate-80 dark:bg-slate-700 rounded-2xl shadow-xl">
             <div className="flex-1 relative pt-16 px-6 pb-8 md:px-8">
               <h2 className="text-xl font-medium text-gray-800 dark:text-gray-200">
                 What is a monorepo
@@ -138,7 +138,7 @@ export function Introduction() {
               </a>
             </div>
           </div>
-          <div className="flex flex-col bg-slate-50 dark:bg-slate-800 rounded-2xl shadow-xl">
+          <div className="flex flex-col bg-slate-50 dark:bg-slate-700 rounded-2xl shadow-xl">
             <div className="flex-1 relative pt-16 px-6 pb-8 md:px-8">
               <h2 className="text-xl font-medium text-gray-800 dark:text-gray-200">
                 Why a monorepo
@@ -157,7 +157,7 @@ export function Introduction() {
               </a>
             </div>
           </div>
-          <div className="flex flex-col bg-slate-50 dark:bg-slate-800 rounded-2xl shadow-xl">
+          <div className="flex flex-col bg-slate-50 dark:bg-slate-700 rounded-2xl shadow-xl">
             <div className="flex-1 relative pt-16 px-6 pb-8 md:px-8">
               <h2 className="text-xl font-medium text-gray-800 dark:text-gray-200">
                 Features of a monorepo


### PR DESCRIPTION
Minor things..

**Before:**

I like them in Desktop mode..

![image](https://user-images.githubusercontent.com/542458/150215884-061535a0-5800-4839-b21b-a34c47214adc.png)

But on mobile they're basically not visible or hard to see

![image](https://user-images.githubusercontent.com/542458/150215874-e5f398a0-6707-4224-bf29-439709f33354.png)

**After:**

Making them a bit lighter works. Open for other suggestions (e.g. add some light border? more shadow around ll the corners ... 🤷‍♂️). Also...the issue kinda persists on light mode

![image](https://user-images.githubusercontent.com/542458/150215722-d1f1dc0a-cfdc-43be-99ed-da1b7591b8d9.png)

![image](https://user-images.githubusercontent.com/542458/150215738-1677730f-3398-47ac-9070-f79d414f0510.png)
