### PR TITLE
fix: bazel can build and test only changed targets

### DIFF
--- a/libs/website/ui-home/src/lib/monorepo-features.tsx
+++ b/libs/website/ui-home/src/lib/monorepo-features.tsx
@@ -591,12 +591,12 @@ export function MonorepoFeatures() {
             <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
               <dt>
                 <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
-                  <ManualImplementation /> Bazel
+                  <Supported /> Bazel
                 </p>
               </dt>
               <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
-                Bazel doesn't support it, but it provides the required metadata
-                making it possible to write such functionality youself.
+                Bazel doesn't tell you what has changed upfront, but it provides the required metadata
+                making it possible to write such functionality yourself.
               </dd>
             </div>
             <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">

--- a/libs/website/ui-home/src/lib/tools-review.tsx
+++ b/libs/website/ui-home/src/lib/tools-review.tsx
@@ -121,7 +121,7 @@ const fast: Item[] = [
       'Determine what might be affected by a change, to run only build/test affected projects.',
     features: [
       { title: 'Nx', value: 'supported' },
-      { title: 'Bazel', value: 'manualImplementation' },
+      { title: 'Bazel', value: 'supported' },
       { title: 'Lage', value: 'supported' },
       { title: 'Turborepo', value: 'supported' },
       { title: 'Lerna', value: 'supported' },


### PR DESCRIPTION
I am not 100% sure about this change. the second part of the sentence sounds misleading because bazel is pretty much capable of building targets that are affected by a change. also capable of telling you a little about what was cached and what had to be built.

Even though it doesn't have a command like `nx affected`, it can still do what nx can do in this manner.