### PR TITLE
fix: Lage link on the introduction component

### DIFF
--- a/libs/website/ui-home/src/lib/introduction.tsx
+++ b/libs/website/ui-home/src/lib/introduction.tsx
@@ -91,7 +91,7 @@ export function Introduction() {
                 ,&nbsp;
                 <a
                   rel="nofollow"
-                  href="https://rushjs.io/"
+                  href="https://microsoft.github.io/lage/"
                   className="border-b border-yellow-500 hover:bg-yellow-500 hover:text-gray-800 transition hover:rounded"
                 >
                   Lage (by Microsoft)


### PR DESCRIPTION
The link was pointing to Rush (also by Microsoft) instead of Lage. This PR fixes this issue.

If this was intended, feel free to close this pr.