### PR TITLE
Add a comparison for RushJS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,9 +29,9 @@ yarn
 To serve the website, run:
 
 ```bash
-yarn serve website
+yarn start
 # is the same as
-yarn run website:serve
+nx run website:serve
 ```
 
 ## Submission Guidelines

--- a/libs/website/ui-home/src/lib/monorepo-features.tsx
+++ b/libs/website/ui-home/src/lib/monorepo-features.tsx
@@ -171,7 +171,7 @@ export function MonorepoFeatures() {
                 </p>
               </dt>
               <dd className="mt-4 text-gray-600 dark:text-gray-400">
-                Rush supports it, and invokes the system tar command to restore
+                Rush supports it, leveraging the system tar command to restore
                 files more quickly.
               </dd>
             </div>
@@ -278,7 +278,7 @@ export function MonorepoFeatures() {
               </dt>
               <dd className="mt-4 text-gray-600 dark:text-gray-400">
                 Rush supports it. Commands can be modeled either as a simple
-                operation or as separate "phases" such as build, test, etc.
+                script or as separate "phases" such as build, test, etc.
               </dd>
             </div>{' '}
             <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
@@ -683,7 +683,7 @@ export function MonorepoFeatures() {
               <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
                 The command line parameters for project selection can detect
                 which projects are impacted by a Git diff. Rush also provides a
-                PackageChangeAnalyzer API for scripts.
+                PackageChangeAnalyzer API for automation scenarios.
               </dd>
             </div>
             <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
@@ -1021,11 +1021,11 @@ export function MonorepoFeatures() {
                 </p>
               </dt>
               <dd className="mt-4 text-gray-600 dark:text-gray-400">
-                Rush supports it, but discourages importing code from folders
-                that are not a declared npm dependency. This ensures that
-                projects can be easily moved between monorepos. For cases where
-                creating a library is too much overhead, "packlets" provide a
-                lightweight alternative.
+                Rush supports it, however discourages importing code from
+                folders that are not a declared npm dependency. This ensures
+                that projects can be easily moved between monorepos. For
+                situations where creating a package is too much overhead,
+                "packlets" offer a lightweight alternative.
               </dd>
             </div>
             <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
@@ -1136,8 +1136,8 @@ export function MonorepoFeatures() {
               <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
                 Rush only builds TypeScript/JavaScript projects, recommending a
                 decoupled approach where native components are built separately
-                using their native toolchains or BuildXL. Ideally Node.js is the
-                only required prerequisite for monorepo developers.
+                using native toolchains or BuildXL. Ideally Node.js is the only
+                required prerequisite for monorepo developers.
               </dd>
             </div>
             <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">

--- a/libs/website/ui-home/src/lib/monorepo-features.tsx
+++ b/libs/website/ui-home/src/lib/monorepo-features.tsx
@@ -120,21 +120,6 @@ export function MonorepoFeatures() {
             <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
               <dt>
                 <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
-                  <Supported /> Nx
-                </p>
-              </dt>
-              <dd className="mt-4 text-gray-600 dark:text-gray-400">
-                Like React, Nx does tree diffing when restoring the results from
-                its cache, which, on average, makes it faster than other tools (
-                <a href="https://github.com/vsavkin/large-monorepo">
-                  see this benchmark comparing Nx, Lage, and Turborepo
-                </a>
-                ).
-              </dd>
-            </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
-              <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
                   <Supported /> Bazel
                 </p>
               </dt>
@@ -155,22 +140,37 @@ export function MonorepoFeatures() {
             <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
               <dt>
                 <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
-                  <Supported /> Turborepo
-                </p>
-              </dt>
-              <dd className="mt-4 text-gray-600 dark:text-gray-400">
-                Turborepo supports it.
-              </dd>
-            </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
-              <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
                   <NotSupported /> Lerna
                 </p>
               </dt>
               <dd className="mt-4 text-gray-600 dark:text-gray-400">
                 Lerna doesn't support it and will always rerun everything from
                 scratch.
+              </dd>
+            </div>
+            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+              <dt>
+                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                  <Supported /> Nx
+                </p>
+              </dt>
+              <dd className="mt-4 text-gray-600 dark:text-gray-400">
+                Like React, Nx does tree diffing when restoring the results from
+                its cache, which, on average, makes it faster than other tools (
+                <a href="https://github.com/vsavkin/large-monorepo">
+                  see this benchmark comparing Nx, Lage, and Turborepo
+                </a>
+                ).
+              </dd>
+            </div>
+            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+              <dt>
+                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                  <Supported /> Turborepo
+                </p>
+              </dt>
+              <dd className="mt-4 text-gray-600 dark:text-gray-400">
+                Turborepo supports it.
               </dd>
             </div>
           </dl>
@@ -218,16 +218,6 @@ export function MonorepoFeatures() {
             <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
               <dt>
                 <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
-                  <Supported /> Nx
-                </p>
-              </dt>
-              <dd className="mt-4 text-gray-600 dark:text-gray-400">
-                Nx supports it.
-              </dd>
-            </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
-              <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
                   <Supported /> Bazel
                 </p>
               </dt>
@@ -248,16 +238,6 @@ export function MonorepoFeatures() {
             <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
               <dt>
                 <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
-                  <Supported /> Turborepo
-                </p>
-              </dt>
-              <dd className="mt-4 text-gray-600 dark:text-gray-400">
-                Turborepo supports it.
-              </dd>
-            </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
-              <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
                   <Supported /> Lerna
                 </p>
               </dt>
@@ -266,6 +246,26 @@ export function MonorepoFeatures() {
                 to the rest of the tools. It is not able to mix and match
                 different targets (e.g., tests and builds), so it results in
                 more idle time.
+              </dd>
+            </div>
+            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+              <dt>
+                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                  <Supported /> Nx
+                </p>
+              </dt>
+              <dd className="mt-4 text-gray-600 dark:text-gray-400">
+                Nx supports it.
+              </dd>
+            </div>
+            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+              <dt>
+                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                  <Supported /> Turborepo
+                </p>
+              </dt>
+              <dd className="mt-4 text-gray-600 dark:text-gray-400">
+                Turborepo supports it.
               </dd>
             </div>
           </dl>
@@ -313,16 +313,6 @@ export function MonorepoFeatures() {
             <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
               <dt>
                 <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
-                  <Supported /> Nx
-                </p>
-              </dt>
-              <dd className="mt-4 text-gray-600 dark:text-gray-400">
-                Nx supports it.
-              </dd>
-            </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
-              <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
                   <Supported /> Bazel
                 </p>
               </dt>
@@ -343,21 +333,31 @@ export function MonorepoFeatures() {
             <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
               <dt>
                 <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
-                  <Supported /> Turborepo
-                </p>
-              </dt>
-              <dd className="mt-4 text-gray-600 dark:text-gray-400">
-                Turborepo supports it.
-              </dd>
-            </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
-              <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
                   <NotSupported /> Lerna
                 </p>
               </dt>
               <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
                 Lerna cannot reuse computation across machines.
+              </dd>
+            </div>
+            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+              <dt>
+                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                  <Supported /> Nx
+                </p>
+              </dt>
+              <dd className="mt-4 text-gray-600 dark:text-gray-400">
+                Nx supports it.
+              </dd>
+            </div>
+            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+              <dt>
+                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                  <Supported /> Turborepo
+                </p>
+              </dt>
+              <dd className="mt-4 text-gray-600 dark:text-gray-400">
+                Turborepo supports it.
               </dd>
             </div>
           </dl>
@@ -405,17 +405,6 @@ export function MonorepoFeatures() {
             <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
               <dt>
                 <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
-                  <Supported /> Nx
-                </p>
-              </dt>
-              <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
-                Nx's implementation isn't as sophisticated as Bazel's but it can
-                be turned on with a small configuration change.
-              </dd>
-            </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
-              <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
                   <Supported /> Bazel
                 </p>
               </dt>
@@ -438,21 +427,32 @@ export function MonorepoFeatures() {
             <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
               <dt>
                 <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
-                  <NotSupported /> Turborepo
-                </p>
-              </dt>
-              <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
-                Turborepo doesn't support it.
-              </dd>
-            </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
-              <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
                   <NotSupported /> Lerna
                 </p>
               </dt>
               <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
                 Lerna doesn't support it.
+              </dd>
+            </div>
+            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+              <dt>
+                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                  <Supported /> Nx
+                </p>
+              </dt>
+              <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
+                Nx's implementation isn't as sophisticated as Bazel's but it can
+                be turned on with a small configuration change.
+              </dd>
+            </div>
+            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+              <dt>
+                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                  <NotSupported /> Turborepo
+                </p>
+              </dt>
+              <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
+                Turborepo doesn't support it.
               </dd>
             </div>
           </dl>
@@ -489,16 +489,6 @@ export function MonorepoFeatures() {
             <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
               <dt>
                 <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
-                  <NotSupported /> Nx
-                </p>
-              </dt>
-              <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
-                Nx doesn't support it.
-              </dd>
-            </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
-              <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
                   <Supported /> Bazel
                 </p>
               </dt>
@@ -519,21 +509,31 @@ export function MonorepoFeatures() {
             <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
               <dt>
                 <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
-                  <NotSupported /> Turborepo
-                </p>
-              </dt>
-              <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
-                Turborepo doesn't support it.
-              </dd>
-            </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
-              <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
                   <NotSupported /> Lerna
                 </p>
               </dt>
               <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
                 Lerna doesn't support it.
+              </dd>
+            </div>
+            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+              <dt>
+                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                  <NotSupported /> Nx
+                </p>
+              </dt>
+              <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
+                Nx doesn't support it.
+              </dd>
+            </div>
+            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+              <dt>
+                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                  <NotSupported /> Turborepo
+                </p>
+              </dt>
+              <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
+                Turborepo doesn't support it.
               </dd>
             </div>
           </dl>
@@ -580,17 +580,6 @@ export function MonorepoFeatures() {
             <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
               <dt>
                 <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
-                  <Supported /> Nx
-                </p>
-              </dt>
-              <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
-                Nx supports it. Its implementation doesn't just look at what
-                files changed but also at the nature of the change.
-              </dd>
-            </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
-              <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
                   <ManualImplementation /> Bazel
                 </p>
               </dt>
@@ -612,21 +601,32 @@ export function MonorepoFeatures() {
             <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
               <dt>
                 <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
-                  <Supported /> Turborepo
-                </p>
-              </dt>
-              <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
-                Turborepo supports it.
-              </dd>
-            </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
-              <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
                   <Supported /> Lerna
                 </p>
               </dt>
               <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
                 Lerna supports it.
+              </dd>
+            </div>
+            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+              <dt>
+                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                  <Supported /> Nx
+                </p>
+              </dt>
+              <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
+                Nx supports it. Its implementation doesn't just look at what
+                files changed but also at the nature of the change.
+              </dd>
+            </div>
+            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+              <dt>
+                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                  <Supported /> Turborepo
+                </p>
+              </dt>
+              <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
+                Turborepo supports it.
               </dd>
             </div>
           </dl>
@@ -679,18 +679,6 @@ export function MonorepoFeatures() {
             <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
               <dt>
                 <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
-                  <Supported /> Nx
-                </p>
-              </dt>
-              <dd className="mt-4 text-gray-600 dark:text-gray-400">
-                By default, Nx analyses <code>package.json</code>, JavaScript,
-                and TypeScript files. It's pluggable and can be extended to
-                support other platforms (e.g, Go, Java, Rust).
-              </dd>
-            </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
-              <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
                   <ManualImplementation /> Bazel
                 </p>
               </dt>
@@ -713,21 +701,33 @@ export function MonorepoFeatures() {
             <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
               <dt>
                 <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
-                  <Supported /> Turborepo
-                </p>
-              </dt>
-              <dd className="mt-4 text-gray-600 dark:text-gray-400">
-                Turborepo analyses package.json files.
-              </dd>
-            </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
-              <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
                   <Supported /> Lerna
                 </p>
               </dt>
               <dd className="mt-4 text-gray-600 dark:text-gray-400">
                 Lerna analyses package.json files.
+              </dd>
+            </div>
+            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+              <dt>
+                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                  <Supported /> Nx
+                </p>
+              </dt>
+              <dd className="mt-4 text-gray-600 dark:text-gray-400">
+                By default, Nx analyses <code>package.json</code>, JavaScript,
+                and TypeScript files. It's pluggable and can be extended to
+                support other platforms (e.g, Go, Java, Rust).
+              </dd>
+            </div>
+            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+              <dt>
+                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                  <Supported /> Turborepo
+                </p>
+              </dt>
+              <dd className="mt-4 text-gray-600 dark:text-gray-400">
+                Turborepo analyses package.json files.
               </dd>
             </div>
           </dl>
@@ -777,17 +777,6 @@ export function MonorepoFeatures() {
             <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
               <dt>
                 <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
-                  <Supported /> Nx
-                </p>
-              </dt>
-              <dd className="mt-4 text-gray-600 dark:text-gray-400">
-                Nx comes ith an interactive visualizer that allows you to filter
-                and explore large workspaces.
-              </dd>
-            </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
-              <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
                   <Supported /> Bazel
                 </p>
               </dt>
@@ -810,23 +799,34 @@ export function MonorepoFeatures() {
             <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
               <dt>
                 <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
-                  <Supported /> Turborepo
-                </p>
-              </dt>
-              <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
-                Turborepo's implementation is not interactive and doesn't
-                provide any way to filter the graph, so works for small repos.
-              </dd>
-            </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
-              <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
                   <ManualImplementation /> Lerna
                 </p>
               </dt>
               <dd className="mt-4 text-gray-600 dark:text-gray-400">
                 Lerna doesn't come with a visualizer but it's possible to write
                 your own.
+              </dd>
+            </div>
+            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+              <dt>
+                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                  <Supported /> Nx
+                </p>
+              </dt>
+              <dd className="mt-4 text-gray-600 dark:text-gray-400">
+                Nx comes ith an interactive visualizer that allows you to filter
+                and explore large workspaces.
+              </dd>
+            </div>
+            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+              <dt>
+                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                  <Supported /> Turborepo
+                </p>
+              </dt>
+              <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
+                Turborepo's implementation is not interactive and doesn't
+                provide any way to filter the graph, so works for small repos.
               </dd>
             </div>
           </dl>
@@ -878,20 +878,6 @@ export function MonorepoFeatures() {
               <dt>
                 <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
                   <Supported />
-                  Nx
-                </p>
-              </dt>
-              <dd className="mt-4 text-gray-600 dark:text-gray-400">
-                Nx supports it. Any folder of files can be marked as a project
-                and can be shared. Nx plugins help configure WebPack, Rollup,
-                TypeScript and other tools to enable sharing without hurting dev
-                ergonomics.
-              </dd>
-            </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
-              <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
-                  <Supported />
                   Bazel
                 </p>
               </dt>
@@ -916,22 +902,36 @@ export function MonorepoFeatures() {
               <dt>
                 <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
                   <Supported />
-                  Turborepo
+                  Lerna
                 </p>
               </dt>
               <dd className="mt-4 text-gray-600 dark:text-gray-400">
-                Turborepo supports it. Only npm packages can be shared.
+                Lerna supports it. Only npm packages can be shared.
               </dd>
             </div>
             <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
               <dt>
                 <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
                   <Supported />
-                  Lerna
+                  Nx
                 </p>
               </dt>
               <dd className="mt-4 text-gray-600 dark:text-gray-400">
-                Lerna supports it. Only npm packages can be shared.
+                Nx supports it. Any folder of files can be marked as a project
+                and can be shared. Nx plugins help configure WebPack, Rollup,
+                TypeScript and other tools to enable sharing without hurting dev
+                ergonomics.
+              </dd>
+            </div>
+            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+              <dt>
+                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                  <Supported />
+                  Turborepo
+                </p>
+              </dt>
+              <dd className="mt-4 text-gray-600 dark:text-gray-400">
+                Turborepo supports it. Only npm packages can be shared.
               </dd>
             </div>
           </dl>
@@ -979,18 +979,6 @@ export function MonorepoFeatures() {
               <dt>
                 <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
                   <Supported />
-                  Nx
-                </p>
-              </dt>
-              <dd className="mt-4 text-gray-600 dark:text-gray-400">
-                Nx is pluggable. It is able to invoke npm scripts by default,
-                but can be extended to invoke other tools (e.g., Gradle).
-              </dd>
-            </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
-              <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
-                  <Supported />
                   Bazel
                 </p>
               </dt>
@@ -1014,22 +1002,34 @@ export function MonorepoFeatures() {
               <dt>
                 <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
                   <NotSupported />
-                  Turborepo
+                  Lerna
                 </p>
               </dt>
               <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
-                Turborepo can only run npm scripts.
+                Lerna can only run npm scripts.
+              </dd>
+            </div>
+            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+              <dt>
+                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                  <Supported />
+                  Nx
+                </p>
+              </dt>
+              <dd className="mt-4 text-gray-600 dark:text-gray-400">
+                Nx is pluggable. It is able to invoke npm scripts by default,
+                but can be extended to invoke other tools (e.g., Gradle).
               </dd>
             </div>
             <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
               <dt>
                 <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
                   <NotSupported />
-                  Lerna
+                  Turborepo
                 </p>
               </dt>
               <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
-                Lerna can only run npm scripts.
+                Turborepo can only run npm scripts.
               </dd>
             </div>
           </dl>
@@ -1075,20 +1075,6 @@ export function MonorepoFeatures() {
             <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
               <dt>
                 <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
-                  <Supported />
-                  Nx
-                </p>
-              </dt>
-              <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
-                Nx comes with powerful code generation capabilities. It uses a
-                virtual file system and provides editor integration. Nx plugins
-                provided generators for popular frameworks. Other generators can
-                be used as well.
-              </dd>
-            </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
-              <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
                   <ManualImplementation />
                   Bazel
                 </p>
@@ -1112,7 +1098,7 @@ export function MonorepoFeatures() {
               <dt>
                 <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
                   <ManualImplementation />
-                  Turborepo
+                  Lerna
                 </p>
               </dt>
               <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
@@ -1122,8 +1108,22 @@ export function MonorepoFeatures() {
             <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
               <dt>
                 <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                  <Supported />
+                  Nx
+                </p>
+              </dt>
+              <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
+                Nx comes with powerful code generation capabilities. It uses a
+                virtual file system and provides editor integration. Nx plugins
+                provided generators for popular frameworks. Other generators can
+                be used as well.
+              </dd>
+            </div>
+            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+              <dt>
+                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
                   <ManualImplementation />
-                  Lerna
+                  Turborepo
                 </p>
               </dt>
               <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
@@ -1179,22 +1179,6 @@ export function MonorepoFeatures() {
               <dt>
                 <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
                   <Supported />
-                  Nx
-                </p>
-              </dt>
-              <dd className="mt-4 text-gray-600 dark:text-gray-400">
-                Developers can annotated projects in any way they seem fit,
-                establish invariants, and Nx will make sure they hold. It allows
-                developers to annotate what is private and what is not, what is
-                experimental and what is stable, etc. Nx also allows you to
-                define public API for each package, so other developers aren't
-                able to deep import into them.
-              </dd>
-            </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
-              <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
-                  <Supported />
                   Bazel
                 </p>
               </dt>
@@ -1219,7 +1203,7 @@ export function MonorepoFeatures() {
               <dt>
                 <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
                   <ManualImplementation />
-                  Turborepo
+                  Lerna
                 </p>
               </dt>
               <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
@@ -1230,8 +1214,24 @@ export function MonorepoFeatures() {
             <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
               <dt>
                 <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                  <Supported />
+                  Nx
+                </p>
+              </dt>
+              <dd className="mt-4 text-gray-600 dark:text-gray-400">
+                Developers can annotated projects in any way they seem fit,
+                establish invariants, and Nx will make sure they hold. It allows
+                developers to annotate what is private and what is not, what is
+                experimental and what is stable, etc. Nx also allows you to
+                define public API for each package, so other developers aren't
+                able to deep import into them.
+              </dd>
+            </div>
+            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+              <dt>
+                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
                   <ManualImplementation />
-                  Lerna
+                  Turborepo
                 </p>
               </dt>
               <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">

--- a/libs/website/ui-home/src/lib/monorepo-features.tsx
+++ b/libs/website/ui-home/src/lib/monorepo-features.tsx
@@ -116,6 +116,7 @@ export function MonorepoFeatures() {
             </div>
           </div>
 
+          {/* (alphabetical order) */}
           <dl className="mt-6 md:mt-0 space-y-6">
             <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
               <dt>
@@ -161,6 +162,17 @@ export function MonorepoFeatures() {
                   see this benchmark comparing Nx, Lage, and Turborepo
                 </a>
                 ).
+              </dd>
+            </div>
+            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+              <dt>
+                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                  <Supported /> Rush
+                </p>
+              </dt>
+              <dd className="mt-4 text-gray-600 dark:text-gray-400">
+                Rush supports it, and invokes the system tar command to restore
+                files more quickly.
               </dd>
             </div>
             <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
@@ -261,6 +273,17 @@ export function MonorepoFeatures() {
             <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
               <dt>
                 <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                  <Supported /> Rush
+                </p>
+              </dt>
+              <dd className="mt-4 text-gray-600 dark:text-gray-400">
+                Rush supports it. Commands can be modeled either as a simple
+                operation or as separate "phases" such as build, test, etc.
+              </dd>
+            </div>{' '}
+            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+              <dt>
+                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
                   <Supported /> Turborepo
                 </p>
               </dt>
@@ -348,6 +371,17 @@ export function MonorepoFeatures() {
               </dt>
               <dd className="mt-4 text-gray-600 dark:text-gray-400">
                 Nx supports it.
+              </dd>
+            </div>
+            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+              <dt>
+                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                  <Supported /> Rush
+                </p>
+              </dt>
+              <dd className="mt-4 text-gray-600 dark:text-gray-400">
+                Rush has built-in support for Azure and AWS storage, with a
+                plugin API allowing custom cache providers.
               </dd>
             </div>
             <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
@@ -448,6 +482,17 @@ export function MonorepoFeatures() {
             <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
               <dt>
                 <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                  <ManualImplementation /> Rush
+                </p>
+              </dt>
+              <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
+                Rush provides this feature by optionally integrating with
+                Microsoft's BuildXL accelerator.
+              </dd>
+            </div>
+            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+              <dt>
+                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
                   <NotSupported /> Turborepo
                 </p>
               </dt>
@@ -524,6 +569,16 @@ export function MonorepoFeatures() {
               </dt>
               <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
                 Nx doesn't support it.
+              </dd>
+            </div>
+            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+              <dt>
+                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                  <NotSupported /> Rush
+                </p>
+              </dt>
+              <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
+                Rush doesn't support it.
               </dd>
             </div>
             <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
@@ -617,6 +672,18 @@ export function MonorepoFeatures() {
               <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
                 Nx supports it. Its implementation doesn't just look at what
                 files changed but also at the nature of the change.
+              </dd>
+            </div>
+            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+              <dt>
+                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                  <Supported /> Rush
+                </p>
+              </dt>
+              <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
+                The command line parameters for project selection can detect
+                which projects are impacted by a Git diff. Rush also provides a
+                PackageChangeAnalyzer API for scripts.
               </dd>
             </div>
             <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
@@ -723,6 +790,18 @@ export function MonorepoFeatures() {
             <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
               <dt>
                 <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                  <Supported /> Rush
+                </p>
+              </dt>
+              <dd className="mt-4 text-gray-600 dark:text-gray-400">
+                Rush projects have the same package.json file and build scripts
+                as a single-repo project. Tooling/configuration is shared across
+                the monorepo by optionally creating "rig packages."
+              </dd>
+            </div>
+            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+              <dt>
+                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
                   <Supported /> Turborepo
                 </p>
               </dt>
@@ -816,6 +895,17 @@ export function MonorepoFeatures() {
               <dd className="mt-4 text-gray-600 dark:text-gray-400">
                 Nx comes ith an interactive visualizer that allows you to filter
                 and explore large workspaces.
+              </dd>
+            </div>
+            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+              <dt>
+                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                  <ManualImplementation /> Rush
+                </p>
+              </dt>
+              <dd className="mt-4 text-gray-600 dark:text-gray-400">
+                Rush doesn't come with a visualizer but it's possible to write
+                your own.
               </dd>
             </div>
             <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
@@ -927,6 +1017,21 @@ export function MonorepoFeatures() {
               <dt>
                 <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
                   <Supported />
+                  Rush
+                </p>
+              </dt>
+              <dd className="mt-4 text-gray-600 dark:text-gray-400">
+                Rush supports it, but discourages importing code from folders
+                that are not a declared npm dependency. This ensures that
+                projects can be easily moved between monorepos. For cases where
+                creating a library is too much overhead, "packlets" provide a
+                lightweight alternative.
+              </dd>
+            </div>
+            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+              <dt>
+                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                  <Supported />
                   Turborepo
                 </p>
               </dt>
@@ -1025,6 +1130,20 @@ export function MonorepoFeatures() {
               <dt>
                 <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
                   <NotSupported />
+                  Rush
+                </p>
+              </dt>
+              <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
+                Rush only builds TypeScript/JavaScript projects, recommending a
+                decoupled approach where native components are built separately
+                using their native toolchains or BuildXL. Ideally Node.js is the
+                only required prerequisite for monorepo developers.
+              </dd>
+            </div>
+            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+              <dt>
+                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                  <NotSupported />
                   Turborepo
                 </p>
               </dt>
@@ -1117,6 +1236,20 @@ export function MonorepoFeatures() {
                 virtual file system and provides editor integration. Nx plugins
                 provided generators for popular frameworks. Other generators can
                 be used as well.
+              </dd>
+            </div>
+            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+              <dt>
+                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                  <ManualImplementation />
+                  Rush
+                </p>
+              </dt>
+              <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
+                The Rush maintainers suggest to maintain project templates as
+                ordinary projects in the monorepo, to ensure they compile
+                without errors. A project scaffolding command is available via a
+                community plugin.
               </dd>
             </div>
             <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
@@ -1225,6 +1358,19 @@ export function MonorepoFeatures() {
                 experimental and what is stable, etc. Nx also allows you to
                 define public API for each package, so other developers aren't
                 able to deep import into them.
+              </dd>
+            </div>
+            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+              <dt>
+                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                  <Supported />
+                  Rush
+                </p>
+              </dt>
+              <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
+                Rush can optionally require approvals when introducing new NPM
+                dependencies (internal or external), based on project type. It
+                also supports version policies for NPM publishing.
               </dd>
             </div>
             <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">

--- a/libs/website/ui-home/src/lib/monorepo-tools-logos.tsx
+++ b/libs/website/ui-home/src/lib/monorepo-tools-logos.tsx
@@ -1,4 +1,5 @@
 const tools: { name: string; link: string }[] = [
+  // Alphabetical order
   {
     name: 'Bazel',
     link: 'https://github.com/bazelbuild/bazel',
@@ -8,16 +9,16 @@ const tools: { name: string; link: string }[] = [
     link: 'https://github.com/microsoft/lage',
   },
   {
+    name: 'Lerna',
+    link: 'https://github.com/lerna/lerna',
+  },
+  {
     name: 'Nx',
     link: 'https://github.com/nrwl/nx',
   },
   {
     name: 'Turborepo',
     link: 'https://github.com/vercel/turborepo',
-  },
-  {
-    name: 'Lerna',
-    link: 'https://github.com/lerna/lerna',
   },
 ];
 

--- a/libs/website/ui-home/src/lib/monorepo-tools-logos.tsx
+++ b/libs/website/ui-home/src/lib/monorepo-tools-logos.tsx
@@ -17,6 +17,10 @@ const tools: { name: string; link: string }[] = [
     link: 'https://github.com/nrwl/nx',
   },
   {
+    name: 'Rush',
+    link: 'https://github.com/microsoft/rushstack',
+  },
+  {
     name: 'Turborepo',
     link: 'https://github.com/vercel/turborepo',
   },
@@ -24,7 +28,7 @@ const tools: { name: string; link: string }[] = [
 
 export function MonorepoToolsLogos() {
   return (
-    <div className="py-12 lg:py-16 mt-8 grid grid-cols-1 gap-0.5 md:grid-cols-5 lg:mt-16 text-3xl font-semibold">
+    <div className="py-12 lg:py-16 mt-8 grid grid-cols-1 gap-0.5 md:grid-cols-6 lg:mt-16 text-3xl font-semibold">
       {tools.map((tool) => (
         <a
           key={'tool-' + tool.name}

--- a/libs/website/ui-home/src/lib/resources.tsx
+++ b/libs/website/ui-home/src/lib/resources.tsx
@@ -35,6 +35,13 @@ const people: {
     twitterLink: 'https://twitter.com/victorsavkin',
     githubLink: 'https://github.com/nrwl/nx',
   },
+  {
+    name: 'Pete Gonzalez',
+    tool: 'Rush',
+    imageUrl: 'https://avatars.githubusercontent.com/u/4673363?s=150',
+    twitterLink: 'https://twitter.com/octogonz_',
+    githubLink: 'https://github.com/microsoft/rushstack',
+  },
 ];
 const videosPodcasts: { name: string; link: string }[] = [
   {

--- a/libs/website/ui-home/src/lib/tools-review.tsx
+++ b/libs/website/ui-home/src/lib/tools-review.tsx
@@ -18,13 +18,6 @@ interface Item {
 
 const tools = [
   {
-    title: 'Nx',
-    organization: 'Nrwl',
-    organizationUrl: 'https://nrwl.io',
-    description:
-      'Next generation build system with first class monorepo support and powerful integrations.',
-  },
-  {
     title: 'Bazel',
     organization: 'Google',
     organizationUrl: 'https://google.com',
@@ -38,16 +31,23 @@ const tools = [
     description: 'Task runner in JS monorepos',
   },
   {
+    title: 'Lerna',
+    description:
+      'A tool for managing JavaScript projects with multiple packages.',
+  },
+  {
+    title: 'Nx',
+    organization: 'Nrwl',
+    organizationUrl: 'https://nrwl.io',
+    description:
+      'Next generation build system with first class monorepo support and powerful integrations.',
+  },
+  {
     title: 'Turborepo',
     organization: 'Vercel',
     organizationUrl: 'https://vercel.com',
     description:
       'The high-performance build system for JavaScript & TypeScript codebases.',
-  },
-  {
-    title: 'Lerna',
-    description:
-      'A tool for managing JavaScript projects with multiple packages.',
   },
 ];
 const fast: Item[] = [
@@ -56,11 +56,11 @@ const fast: Item[] = [
     link: '#local-task-orchestration',
     tooltip: 'The ability to run tasks in the correct order and in parallel.',
     features: [
-      { title: 'Nx', value: 'supported' },
       { title: 'Bazel', value: 'supported' },
       { title: 'Lage', value: 'supported' },
-      { title: 'Turborepo', value: 'supported' },
       { title: 'Lerna', value: 'supported' },
+      { title: 'Nx', value: 'supported' },
+      { title: 'Turborepo', value: 'supported' },
     ],
   },
   {
@@ -69,11 +69,11 @@ const fast: Item[] = [
     tooltip:
       'The ability to store and replay file and process output of tasks.',
     features: [
-      { title: 'Nx', value: 'supported' },
       { title: 'Bazel', value: 'supported' },
       { title: 'Lage', value: 'supported' },
-      { title: 'Turborepo', value: 'supported' },
       { title: 'Lerna', value: 'notSupported' },
+      { title: 'Nx', value: 'supported' },
+      { title: 'Turborepo', value: 'supported' },
     ],
   },
   {
@@ -82,11 +82,11 @@ const fast: Item[] = [
     tooltip:
       'The ability to share cache artifacts across different environments.',
     features: [
-      { title: 'Nx', value: 'supported' },
       { title: 'Bazel', value: 'supported' },
       { title: 'Lage', value: 'supported' },
-      { title: 'Turborepo', value: 'supported' },
       { title: 'Lerna', value: 'notSupported' },
+      { title: 'Nx', value: 'supported' },
+      { title: 'Turborepo', value: 'supported' },
     ],
   },
   {
@@ -94,11 +94,11 @@ const fast: Item[] = [
     link: '#distributed-task-execution',
     tooltip: 'The ability to distribute a command across many machines.',
     features: [
-      { title: 'Nx', value: 'supported' },
       { title: 'Bazel', value: 'supported' },
       { title: 'Lage', value: 'notSupported' },
-      { title: 'Turborepo', value: 'notSupported' },
       { title: 'Lerna', value: 'notSupported' },
+      { title: 'Nx', value: 'supported' },
+      { title: 'Turborepo', value: 'notSupported' },
     ],
   },
   {
@@ -107,11 +107,11 @@ const fast: Item[] = [
     tooltip:
       'The ability to execute any command on multiple machines while developing locally.',
     features: [
-      { title: 'Nx', value: 'notSupported' },
       { title: 'Bazel', value: 'supported' },
       { title: 'Lage', value: 'notSupported' },
-      { title: 'Turborepo', value: 'notSupported' },
       { title: 'Lerna', value: 'notSupported' },
+      { title: 'Nx', value: 'notSupported' },
+      { title: 'Turborepo', value: 'notSupported' },
     ],
   },
   {
@@ -120,11 +120,11 @@ const fast: Item[] = [
     tooltip:
       'Determine what might be affected by a change, to run only build/test affected projects.',
     features: [
-      { title: 'Nx', value: 'supported' },
       { title: 'Bazel', value: 'manualImplementation' },
       { title: 'Lage', value: 'supported' },
-      { title: 'Turborepo', value: 'supported' },
       { title: 'Lerna', value: 'supported' },
+      { title: 'Nx', value: 'supported' },
+      { title: 'Turborepo', value: 'supported' },
     ],
   },
 ];
@@ -135,11 +135,11 @@ const understandable: Item[] = [
     tooltip:
       'The ability to understand the understand the project graph of the workspace without extra configuration.',
     features: [
-      { title: 'Nx', value: 'supported' },
       { title: 'Bazel', value: 'manualImplementation' },
       { title: 'Lage', value: 'supported' },
-      { title: 'Turborepo', value: 'supported' },
+      { title: 'Nx', value: 'supported' },
       { title: 'Lerna', value: 'supported' },
+      { title: 'Turborepo', value: 'supported' },
     ],
   },
   {
@@ -148,11 +148,11 @@ const understandable: Item[] = [
     tooltip:
       'Visualize dependency relationships between projects and/or tasks.',
     features: [
-      { title: 'Nx', value: 'supported' },
       { title: 'Bazel', value: 'supported' },
       { title: 'Lage', value: 'manualImplementation' },
-      { title: 'Turborepo', value: 'supported' },
       { title: 'Lerna', value: 'manualImplementation' },
+      { title: 'Nx', value: 'supported' },
+      { title: 'Turborepo', value: 'supported' },
     ],
   },
 ];
@@ -162,11 +162,11 @@ const manageable: Item[] = [
     link: '#source-code-sharing',
     tooltip: 'Facilitates sharing of discrete pieces source code.',
     features: [
-      { title: 'Nx', value: 'supported' },
       { title: 'Bazel', value: 'supported' },
       { title: 'Lage', value: 'supported' },
-      { title: 'Turborepo', value: 'supported' },
       { title: 'Lerna', value: 'supported' },
+      { title: 'Nx', value: 'supported' },
+      { title: 'Turborepo', value: 'supported' },
     ],
   },
   {
@@ -175,11 +175,11 @@ const manageable: Item[] = [
     tooltip:
       'The tool helps you get a consistent experience regardless of what you use to develop your projects: different JavaScript frameworks, Go, Java, etc.',
     features: [
-      { title: 'Nx', value: 'supported' },
       { title: 'Bazel', value: 'supported' },
       { title: 'Lage', value: 'notSupported' },
-      { title: 'Turborepo', value: 'notSupported' },
       { title: 'Lerna', value: 'notSupported' },
+      { title: 'Nx', value: 'supported' },
+      { title: 'Turborepo', value: 'notSupported' },
     ],
   },
   {
@@ -187,11 +187,11 @@ const manageable: Item[] = [
     link: '#code-generation',
     tooltip: 'Native support for generating code',
     features: [
-      { title: 'Nx', value: 'supported' },
       { title: 'Bazel', value: 'manualImplementation' },
       { title: 'Lage', value: 'manualImplementation' },
-      { title: 'Turborepo', value: 'manualImplementation' },
+      { title: 'Nx', value: 'supported' },
       { title: 'Lerna', value: 'manualImplementation' },
+      { title: 'Turborepo', value: 'manualImplementation' },
     ],
   },
   {
@@ -200,11 +200,11 @@ const manageable: Item[] = [
     tooltip:
       'Supports definition of rules to constrain dependency relationships within the repo.',
     features: [
-      { title: 'Nx', value: 'supported' },
       { title: 'Bazel', value: 'supported' },
       { title: 'Lage', value: 'manualImplementation' },
-      { title: 'Turborepo', value: 'manualImplementation' },
       { title: 'Lerna', value: 'manualImplementation' },
+      { title: 'Nx', value: 'supported' },
+      { title: 'Turborepo', value: 'manualImplementation' },
     ],
   },
 ];

--- a/libs/website/ui-home/src/lib/tools-review.tsx
+++ b/libs/website/ui-home/src/lib/tools-review.tsx
@@ -16,6 +16,7 @@ interface Item {
   link: string;
 }
 
+// alphabetical order
 const tools = [
   {
     title: 'Bazel',
@@ -43,6 +44,13 @@ const tools = [
       'Next generation build system with first class monorepo support and powerful integrations.',
   },
   {
+    title: 'Rush',
+    organization: 'Microsoft',
+    organizationUrl: 'https://microsoft.com',
+    description:
+      'Geared for large monorepos with lots of teams and projects. Part of the Rush Stack family of projects.',
+  },
+  {
     title: 'Turborepo',
     organization: 'Vercel',
     organizationUrl: 'https://vercel.com',
@@ -60,6 +68,7 @@ const fast: Item[] = [
       { title: 'Lage', value: 'supported' },
       { title: 'Lerna', value: 'supported' },
       { title: 'Nx', value: 'supported' },
+      { title: 'Rush', value: 'supported' },
       { title: 'Turborepo', value: 'supported' },
     ],
   },
@@ -73,6 +82,7 @@ const fast: Item[] = [
       { title: 'Lage', value: 'supported' },
       { title: 'Lerna', value: 'notSupported' },
       { title: 'Nx', value: 'supported' },
+      { title: 'Rush', value: 'supported' },
       { title: 'Turborepo', value: 'supported' },
     ],
   },
@@ -86,6 +96,7 @@ const fast: Item[] = [
       { title: 'Lage', value: 'supported' },
       { title: 'Lerna', value: 'notSupported' },
       { title: 'Nx', value: 'supported' },
+      { title: 'Rush', value: 'supported' },
       { title: 'Turborepo', value: 'supported' },
     ],
   },
@@ -98,6 +109,7 @@ const fast: Item[] = [
       { title: 'Lage', value: 'notSupported' },
       { title: 'Lerna', value: 'notSupported' },
       { title: 'Nx', value: 'supported' },
+      { title: 'Rush', value: 'manualImplementation' },
       { title: 'Turborepo', value: 'notSupported' },
     ],
   },
@@ -111,6 +123,7 @@ const fast: Item[] = [
       { title: 'Lage', value: 'notSupported' },
       { title: 'Lerna', value: 'notSupported' },
       { title: 'Nx', value: 'notSupported' },
+      { title: 'Rush', value: 'notSupported' },
       { title: 'Turborepo', value: 'notSupported' },
     ],
   },
@@ -124,6 +137,7 @@ const fast: Item[] = [
       { title: 'Lage', value: 'supported' },
       { title: 'Lerna', value: 'supported' },
       { title: 'Nx', value: 'supported' },
+      { title: 'Rush', value: 'supported' },
       { title: 'Turborepo', value: 'supported' },
     ],
   },
@@ -139,6 +153,7 @@ const understandable: Item[] = [
       { title: 'Lage', value: 'supported' },
       { title: 'Nx', value: 'supported' },
       { title: 'Lerna', value: 'supported' },
+      { title: 'Rush', value: 'supported' },
       { title: 'Turborepo', value: 'supported' },
     ],
   },
@@ -152,6 +167,7 @@ const understandable: Item[] = [
       { title: 'Lage', value: 'manualImplementation' },
       { title: 'Lerna', value: 'manualImplementation' },
       { title: 'Nx', value: 'supported' },
+      { title: 'Rush', value: 'manualImplementation' },
       { title: 'Turborepo', value: 'supported' },
     ],
   },
@@ -166,6 +182,7 @@ const manageable: Item[] = [
       { title: 'Lage', value: 'supported' },
       { title: 'Lerna', value: 'supported' },
       { title: 'Nx', value: 'supported' },
+      { title: 'Rush', value: 'supported' },
       { title: 'Turborepo', value: 'supported' },
     ],
   },
@@ -179,6 +196,7 @@ const manageable: Item[] = [
       { title: 'Lage', value: 'notSupported' },
       { title: 'Lerna', value: 'notSupported' },
       { title: 'Nx', value: 'supported' },
+      { title: 'Rush', value: 'notSupported' },
       { title: 'Turborepo', value: 'notSupported' },
     ],
   },
@@ -191,6 +209,7 @@ const manageable: Item[] = [
       { title: 'Lage', value: 'manualImplementation' },
       { title: 'Nx', value: 'supported' },
       { title: 'Lerna', value: 'manualImplementation' },
+      { title: 'Rush', value: 'manualImplementation' },
       { title: 'Turborepo', value: 'manualImplementation' },
     ],
   },
@@ -204,6 +223,7 @@ const manageable: Item[] = [
       { title: 'Lage', value: 'manualImplementation' },
       { title: 'Lerna', value: 'manualImplementation' },
       { title: 'Nx', value: 'supported' },
+      { title: 'Rush', value: 'supported' },
       { title: 'Turborepo', value: 'manualImplementation' },
     ],
   },
@@ -444,14 +464,14 @@ export function ToolsReview() {
       <section className="hidden lg:block">
         <div className="max-w-7xl mx-auto py-24 px-8">
           <div className="w-full border-t border-slate-100 dark:border-slate-900 flex items-stretch">
-            <div className="-mt-px w-1/6 py-6 pr-4 flex items-end" />
+            <div className="-mt-px w-[14.3%] py-6 pr-4 flex items-end" />
             {tools.map((tool, toolIndex) => (
               <div
                 key={tool.title}
                 aria-hidden="true"
                 className={classNames(
                   toolIndex === tools.length - 1 ? '' : 'pr-4',
-                  '-mt-px pl-4 w-1/6'
+                  '-mt-px pl-4 w-[14.3%]'
                 )}
               >
                 <div className="border-transparent py-6 border-t-2">
@@ -472,7 +492,7 @@ export function ToolsReview() {
           </div>
 
           <div className="w-full border-t border-slate-100 dark:border-slate-900 flex items-stretch">
-            <div className="-mt-px w-1/6 py-6 pr-4 flex items-end">
+            <div className="-mt-px w-[14.3%] py-6 pr-4 flex items-end">
               <h3 className="mt-auto text-sm font-bold text-gray-700 dark:text-gray-300">
                 Fast
               </h3>
@@ -484,20 +504,23 @@ export function ToolsReview() {
               className="absolute inset-0 flex items-stretch pointer-events-none"
               aria-hidden="true"
             >
-              <div className="w-1/6 pr-5" />
-              <div className="w-1/6 px-5">
+              <div className="w-[14.3%] pr-5" />
+              <div className="w-[14.3%] px-5">
                 <div className="w-full h-full bg-slate-100 dark:bg-slate-700 rounded-lg shadow" />
               </div>
-              <div className="w-1/6 px-5">
+              <div className="w-[14.3%] px-5">
                 <div className="w-full h-full bg-slate-100 dark:bg-slate-700 rounded-lg shadow-md" />
               </div>
-              <div className="w-1/6 px-5">
+              <div className="w-[14.3%] px-5">
                 <div className="w-full h-full bg-slate-100 dark:bg-slate-700 rounded-lg shadow-md" />
               </div>
-              <div className="w-1/6 pl-5">
+              <div className="w-[14.3%] pl-5">
                 <div className="w-full h-full bg-slate-100 dark:bg-slate-700 rounded-lg shadow" />
               </div>
-              <div className="w-1/6 pl-5">
+              <div className="w-[14.3%] pl-5">
+                <div className="w-full h-full bg-slate-100 dark:bg-slate-700 rounded-lg shadow" />
+              </div>
+              <div className="w-[14.3%] pl-5">
                 <div className="w-full h-full bg-slate-100 dark:bg-slate-700 rounded-lg shadow" />
               </div>
             </div>
@@ -521,7 +544,7 @@ export function ToolsReview() {
                   <tr key={feature.title}>
                     <th
                       scope="row"
-                      className="w-1/6 py-3 pr-4 text-left text-sm font-medium text-gray-700 dark:text-gray-300"
+                      className="w-[14.3%] py-3 pr-4 text-left text-sm font-medium text-gray-700 dark:text-gray-300"
                     >
                       <a
                         href={feature.link}
@@ -538,7 +561,7 @@ export function ToolsReview() {
                           tierIdx === feature.features.length - 1
                             ? 'pl-4'
                             : 'px-4',
-                          'relative w-1/6 py-0 text-center'
+                          'relative w-[14.3%] py-0 text-center'
                         )}
                       >
                         <span className="relative w-full h-full py-3">
@@ -556,20 +579,23 @@ export function ToolsReview() {
               className="absolute inset-0 flex items-stretch pointer-events-none"
               aria-hidden="true"
             >
-              <div className="w-1/6 pr-5" />
-              <div className="w-1/6 px-5">
+              <div className="w-[14.3%] pr-5" />
+              <div className="w-[14.3%] px-5">
                 <div className="w-full h-full rounded-lg ring-1 ring-black ring-opacity-5" />
               </div>
-              <div className="w-1/6 px-5">
+              <div className="w-[14.3%] px-5">
                 <div className="w-full h-full rounded-lg ring-2 ring-black ring-opacity-5" />
               </div>
-              <div className="w-1/6 px-5">
+              <div className="w-[14.3%] px-5">
                 <div className="w-full h-full rounded-lg ring-2 ring-black ring-opacity-5" />
               </div>
-              <div className="w-1/6 pl-5">
+              <div className="w-[14.3%] pl-5">
                 <div className="w-full h-full rounded-lg ring-1 ring-black ring-opacity-5" />
               </div>
-              <div className="w-1/6 pl-5">
+              <div className="w-[14.3%] pl-5">
+                <div className="w-full h-full rounded-lg ring-1 ring-black ring-opacity-5" />
+              </div>
+              <div className="w-[14.3%] pl-5">
                 <div className="w-full h-full rounded-lg ring-1 ring-black ring-opacity-5" />
               </div>
             </div>
@@ -584,20 +610,23 @@ export function ToolsReview() {
               className="absolute inset-0 flex items-stretch pointer-events-none"
               aria-hidden="true"
             >
-              <div className="w-1/6 pr-4" />
-              <div className="w-1/6 px-4">
+              <div className="w-[14.3%] pr-4" />
+              <div className="w-[14.3%] px-4">
                 <div className="w-full h-full bg-slate-100 dark:bg-slate-700 rounded-lg shadow" />
               </div>
-              <div className="w-1/6 px-4">
+              <div className="w-[14.3%] px-4">
                 <div className="w-full h-full bg-slate-100 dark:bg-slate-700 rounded-lg shadow-md" />
               </div>
-              <div className="w-1/6 px-4">
+              <div className="w-[14.3%] px-4">
                 <div className="w-full h-full bg-slate-100 dark:bg-slate-700 rounded-lg shadow-md" />
               </div>
-              <div className="w-1/6 px-4">
+              <div className="w-[14.3%] px-4">
                 <div className="w-full h-full bg-slate-100 dark:bg-slate-700 rounded-lg shadow-md" />
               </div>
-              <div className="w-1/6 pl-4">
+              <div className="w-[14.3%] px-4">
+                <div className="w-full h-full bg-slate-100 dark:bg-slate-700 rounded-lg shadow-md" />
+              </div>
+              <div className="w-[14.3%] pl-4">
                 <div className="w-full h-full bg-slate-100 dark:bg-slate-700 rounded-lg shadow" />
               </div>
             </div>
@@ -631,7 +660,7 @@ export function ToolsReview() {
                   <tr key={feature.title}>
                     <th
                       scope="row"
-                      className="w-1/6 py-3 pr-4 text-left text-sm font-medium text-gray-700 dark:text-gray-300"
+                      className="w-[14.3%] py-3 pr-4 text-left text-sm font-medium text-gray-700 dark:text-gray-300"
                     >
                       <a
                         href={feature.link}
@@ -648,7 +677,7 @@ export function ToolsReview() {
                           tierIdx === feature.features.length - 1
                             ? 'pl-4'
                             : 'px-4',
-                          'relative w-1/6 py-0 text-center'
+                          'relative w-[14.3%] py-0 text-center'
                         )}
                       >
                         {valuesDictionary[tier.value]()}
@@ -664,20 +693,23 @@ export function ToolsReview() {
               className="absolute inset-0 flex items-stretch pointer-events-none"
               aria-hidden="true"
             >
-              <div className="w-1/6 pr-4" />
-              <div className="w-1/6 px-4">
+              <div className="w-[14.3%] pr-4" />
+              <div className="w-[14.3%] px-4">
                 <div className="w-full h-full rounded-lg ring-1 ring-black ring-opacity-5" />
               </div>
-              <div className="w-1/6 px-4">
+              <div className="w-[14.3%] px-4">
                 <div className="w-full h-full rounded-lg ring-2 ring-black ring-opacity-5" />
               </div>
-              <div className="w-1/6 px-4">
+              <div className="w-[14.3%] px-4">
                 <div className="w-full h-full rounded-lg ring-2 ring-black ring-opacity-5" />
               </div>
-              <div className="w-1/6 px-4">
+              <div className="w-[14.3%] px-4">
                 <div className="w-full h-full rounded-lg ring-2 ring-black ring-opacity-5" />
               </div>
-              <div className="w-1/6 pl-4">
+              <div className="w-[14.3%] px-4">
+                <div className="w-full h-full rounded-lg ring-2 ring-black ring-opacity-5" />
+              </div>
+              <div className="w-[14.3%] pl-4">
                 <div className="w-full h-full rounded-lg ring-1 ring-black ring-opacity-5" />
               </div>
             </div>
@@ -692,20 +724,23 @@ export function ToolsReview() {
               className="absolute inset-0 flex items-stretch pointer-events-none"
               aria-hidden="true"
             >
-              <div className="w-1/6 pr-4" />
-              <div className="w-1/6 px-4">
+              <div className="w-[14.3%] pr-4" />
+              <div className="w-[14.3%] px-4">
                 <div className="w-full h-full bg-slate-100 dark:bg-slate-700 rounded-lg shadow" />
               </div>
-              <div className="w-1/6 px-4">
+              <div className="w-[14.3%] px-4">
                 <div className="w-full h-full bg-slate-100 dark:bg-slate-700 rounded-lg shadow-md" />
               </div>
-              <div className="w-1/6 px-4">
+              <div className="w-[14.3%] px-4">
                 <div className="w-full h-full bg-slate-100 dark:bg-slate-700 rounded-lg shadow-md" />
               </div>
-              <div className="w-1/6 px-4">
+              <div className="w-[14.3%] px-4">
                 <div className="w-full h-full bg-slate-100 dark:bg-slate-700 rounded-lg shadow-md" />
               </div>
-              <div className="w-1/6 pl-4">
+              <div className="w-[14.3%] px-4">
+                <div className="w-full h-full bg-slate-100 dark:bg-slate-700 rounded-lg shadow-md" />
+              </div>
+              <div className="w-[14.3%] pl-4">
                 <div className="w-full h-full bg-slate-100 dark:bg-slate-700 rounded-lg shadow" />
               </div>
             </div>
@@ -729,7 +764,7 @@ export function ToolsReview() {
                   <tr key={feature.title}>
                     <th
                       scope="row"
-                      className="w-1/6 py-3 pr-4 text-left text-sm font-medium text-gray-700 dark:text-gray-300"
+                      className="w-[14.3%] py-3 pr-4 text-left text-sm font-medium text-gray-700 dark:text-gray-300"
                     >
                       <a
                         href={feature.link}
@@ -746,7 +781,7 @@ export function ToolsReview() {
                           tierIdx === feature.features.length - 1
                             ? 'pl-4'
                             : 'px-4',
-                          'relative w-1/6 py-0 text-center'
+                          'relative w-[14.3%] py-0 text-center'
                         )}
                       >
                         {valuesDictionary[tier.value]()}
@@ -762,20 +797,23 @@ export function ToolsReview() {
               className="absolute inset-0 flex items-stretch pointer-events-none"
               aria-hidden="true"
             >
-              <div className="w-1/6 pr-4" />
-              <div className="w-1/6 px-4">
+              <div className="w-[14.3%] pr-4" />
+              <div className="w-[14.3%] px-4">
                 <div className="w-full h-full rounded-lg ring-1 ring-black ring-opacity-5" />
               </div>
-              <div className="w-1/6 px-4">
+              <div className="w-[14.3%] px-4">
                 <div className="w-full h-full rounded-lg ring-2 ring-black ring-opacity-5" />
               </div>
-              <div className="w-1/6 px-4">
+              <div className="w-[14.3%] px-4">
                 <div className="w-full h-full rounded-lg ring-2 ring-black ring-opacity-5" />
               </div>
-              <div className="w-1/6 px-4">
+              <div className="w-[14.3%] px-4">
                 <div className="w-full h-full rounded-lg ring-2 ring-black ring-opacity-5" />
               </div>
-              <div className="w-1/6 pl-4">
+              <div className="w-[14.3%] px-4">
+                <div className="w-full h-full rounded-lg ring-2 ring-black ring-opacity-5" />
+              </div>
+              <div className="w-[14.3%] pl-4">
                 <div className="w-full h-full rounded-lg ring-1 ring-black ring-opacity-5" />
               </div>
             </div>


### PR DESCRIPTION
- Added a column for [RushJS](https://rushjs.io/) from [Rush Stack](https://rushstack.io/)
- Sort the tools in alphabetical order to avoid the appearance of favoritism (to facilitate code review, this change is isolated in 10d654c382c725aec906f29dc47517988cfb634d) 
- Fixed a shell command in CONTRIBUTING.md that did not work
