### PR TITLE
chore(core): add prettier plugin tailwindcss

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,11 +111,11 @@ jobs:
             pids=()
             yarn nx workspace-lint &
             pids+=($!)
-            yarn nx affected --target=lint --base=$NX_BASE --head=$NX_HEAD --parallel=3 &
+            yarn nx affected --target=lint --base=$NX_BASE --head=$NX_HEAD --parallel=2 &
             pids+=($!)
             yarn nx affected --target=test --base=$NX_BASE --head=$NX_HEAD --parallel=1 &
             pids+=($!)
-            yarn nx affected --target=build --base=$NX_BASE --head=$NX_HEAD --parallel=3 &
+            yarn nx affected --target=build --base=$NX_BASE --head=$NX_HEAD --parallel=2 &
             pids+=($!)
             for pid in "${pids[@]}"; do
               wait "$pid"

--- a/apps/website/pages/_app.tsx
+++ b/apps/website/pages/_app.tsx
@@ -46,7 +46,7 @@ function CustomApp({ Component, pageProps }: AppProps) {
         }}
       />
       <ThemeProvider attribute="class">
-        <main className="monorepo.tools antialiased bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 font-display">
+        <main className="monorepo.tools font-display bg-slate-50 text-gray-700 antialiased dark:bg-slate-800 dark:text-gray-300">
           <Component {...pageProps} />
         </main>
       </ThemeProvider>

--- a/libs/website/ui-commons/src/lib/footer.tsx
+++ b/libs/website/ui-commons/src/lib/footer.tsx
@@ -1,7 +1,7 @@
 export function Footer() {
   return (
-    <footer className="mt-24 lg:mt-36 bg-slate-50 dark:bg-slate-800">
-      <div className="max-w-7xl mx-auto py-12 px-4 overflow-hidden sm:px-6 lg:px-8">
+    <footer className="mt-24 bg-slate-50 dark:bg-slate-800 lg:mt-36">
+      <div className="mx-auto max-w-7xl overflow-hidden py-12 px-4 sm:px-6 lg:px-8">
         <nav
           className="-mx-5 -my-2 flex flex-wrap justify-center"
           aria-label="Footer"

--- a/libs/website/ui-commons/src/lib/header.tsx
+++ b/libs/website/ui-commons/src/lib/header.tsx
@@ -38,7 +38,7 @@ export function Header() {
           backgroundSize: '1200px 600px',
         }}
       >
-        <header className="relative md:min-h-screen px-4 py-24 sm:px-6 md:grid md:place-items-center lg:px-8">
+        <header className="relative px-4 py-24 sm:px-6 md:grid md:min-h-screen md:place-items-center lg:px-8">
           <div className="absolute right-4 top-5 space-x-4 text-gray-300 dark:text-gray-600">
             {!isMounted
               ? null
@@ -52,25 +52,25 @@ export function Header() {
                     title={variant.label}
                     onClick={() => setTheme(variant.value)}
                   >
-                    <variant.icon className="w-6 h-6" />
+                    <variant.icon className="h-6 w-6" />
                     <span className="sr-only">{variant.label}</span>
                   </button>
                 ))}
           </div>
-          <div className="max-w-max mx-auto">
+          <div className="mx-auto max-w-max">
             <div data-test-id="website-name" className="w-full">
-              <span className="text-5xl font-extrabold text-gray-900 dark:text-white tracking-tighter sm:text-8xl">
+              <span className="text-5xl font-extrabold tracking-tighter text-gray-900 dark:text-white sm:text-8xl">
                 monorepo
               </span>
-              <span className="text-3xl font-semibold text-yellow-500 tracking-tight sm:text-5xl">
+              <span className="text-3xl font-semibold tracking-tight text-yellow-500 sm:text-5xl">
                 .tools
               </span>
             </div>
             <div className="mt-14 flex justify-end">
-              <div className="sm:w-2/3 sm:border-l-4 border-yellow-500">
+              <div className="border-yellow-500 sm:w-2/3 sm:border-l-4">
                 <h1
                   data-test-id="website-slogan"
-                  className="pl-8 py-3 text-2xl font-normal text-gray-800 dark:text-gray-200"
+                  className="py-3 pl-8 text-2xl font-normal text-gray-800 dark:text-gray-200"
                 >
                   Everything you need to know about monorepos, and the tools to
                   build them.
@@ -99,10 +99,10 @@ export function Header() {
             title="Go to Understanding Monorepos"
             href="#understanding-monorepos"
             aria-hidden="true"
-            className="absolute hidden lg:block left-1/2 -ml-4 bottom-2"
+            className="absolute left-1/2 bottom-2 -ml-4 hidden lg:block"
           >
             <svg
-              className="animate-pulse w-14 h-14 text-yellow-500"
+              className="h-14 w-14 animate-pulse text-yellow-500"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"

--- a/libs/website/ui-home/src/lib/conclusion.tsx
+++ b/libs/website/ui-home/src/lib/conclusion.tsx
@@ -4,43 +4,43 @@ export function Conclusion() {
   return (
     <article
       id="perception-shift"
-      className="bg-slate-50 dark:bg-slate-800 pt-16 pb-20 px-4 sm:px-6 lg:pt-24 lg:pb-28 lg:px-8"
+      className="bg-slate-50 px-4 pt-16 pb-20 dark:bg-slate-800 sm:px-6 lg:px-8 lg:pt-24 lg:pb-28"
     >
       <div className="relative">
-        <h1 className="text-center text-4xl leading-8 font-extrabold tracking-tight text-gray-900 dark:text-white sm:text-5xl group">
+        <h1 className="group text-center text-4xl font-extrabold leading-8 tracking-tight text-gray-900 dark:text-white sm:text-5xl">
           # A perception shift
           <a
             aria-hidden="true"
             tabIndex={-1}
             href="#perception-shift"
-            className="text-gray-900 dark:text-white flex inline-flex items-center"
+            className="flex inline-flex items-center text-gray-900 dark:text-white"
           >
             <LinkIcon className="ml-2 h-6 w-6 opacity-0 group-hover:opacity-100" />
           </a>
         </h1>
-        <p className="mt-4 max-w-3xl mx-auto text-center text-xl text-gray-700 dark:text-gray-300">
+        <p className="mx-auto mt-4 max-w-3xl text-center text-xl text-gray-700 dark:text-gray-300">
           It's complex, we know. But you're not alone in this journey.
         </p>
       </div>
-      <div className="mt-24 lg:mt-36 relative max-w-lg mx-auto lg:max-w-7xl">
-        <div className="max-w-2xl mx-auto">
+      <div className="relative mx-auto mt-24 max-w-lg lg:mt-36 lg:max-w-7xl">
+        <div className="mx-auto max-w-2xl">
           <h2
             id="monorepo-changes-your-organization"
-            className="text-3xl tracking-tight font-semiboldtext-gray-800 dark:text-gray-100sm:text-4xl group"
+            className="font-semiboldtext-gray-800 dark:text-gray-100sm:text-4xl group text-3xl tracking-tight"
           >
             A monorepo changes your organization
             <a
               aria-hidden="true"
               tabIndex={-1}
               href="#monorepo-changes-your-organization"
-              className="text-gray-900 dark:text-white flex inline-flex items-center"
+              className="flex inline-flex items-center text-gray-900 dark:text-white"
             >
               <LinkIcon className="ml-2 h-6 w-6 opacity-0 group-hover:opacity-100" />
             </a>
           </h2>
           <p className="mt-3 text-xl text-gray-700 dark:text-gray-300 sm:mt-4">
             It is more than code & tools.{' '}
-            <mark className="px-1 bg-yellow-500 rounded-md">
+            <mark className="rounded-md bg-yellow-500 px-1">
               A monorepo changes your organization
             </mark>{' '}
             & the way you think about code. By adding consistency, lowering the

--- a/libs/website/ui-home/src/lib/introduction.tsx
+++ b/libs/website/ui-home/src/lib/introduction.tsx
@@ -4,32 +4,32 @@ export function Introduction() {
   return (
     <div className="mt-32 bg-slate-50 dark:bg-slate-800">
       {/* Header */}
-      <article className="relative md:pt-64 pb-32 bg-slate-50 dark:bg-slate-800">
+      <article className="relative bg-slate-50 pb-32 dark:bg-slate-800 md:pt-64">
         <div className="absolute inset-0">
           <img
             aria-hidden="true"
-            className="w-full h-full object-cover"
+            className="h-full w-full object-cover"
             src="https://images.unsplash.com/photo-1491895200222-0fc4a4c35e18?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1974&q=80"
             alt="cover"
           />
           <div
-            className="absolute inset-0 bg-slate-50 dark:bg-slate-800 mix-blend-lighten dark:mix-blend-multiply"
+            className="absolute inset-0 bg-slate-50 mix-blend-lighten dark:bg-slate-800 dark:mix-blend-multiply"
             aria-hidden="true"
           />
         </div>
-        <div className="relative max-w-7xl mx-auto py-24 px-4 sm:py-32 sm:px-6 lg:px-8">
-          <div className="lg:grid lg:grid-cols-2 lg:gap-16 lg:items-center">
+        <div className="relative mx-auto max-w-7xl py-24 px-4 sm:py-32 sm:px-6 lg:px-8">
+          <div className="lg:grid lg:grid-cols-2 lg:items-center lg:gap-16">
             <div>
               <h1
                 id="understanding-monorepos"
-                className="text-4xl font-extrabold tracking-tight text-gray-900 dark:text-white md:text-5xl lg:text-6xl group"
+                className="group text-4xl font-extrabold tracking-tight text-gray-900 dark:text-white md:text-5xl lg:text-6xl"
               >
                 Understanding Monorepos{' '}
                 <a
                   aria-hidden="true"
                   tabIndex={-1}
                   href="#understanding-monorepos"
-                  className="text-gray-900 dark:text-white flex inline-flex items-center"
+                  className="flex inline-flex items-center text-gray-900 dark:text-white"
                 >
                   <LinkIcon className="ml-2 h-6 w-6 opacity-0 group-hover:opacity-100" />
                 </a>
@@ -37,15 +37,15 @@ export function Introduction() {
               <p className="mt-6 max-w-3xl text-xl text-gray-700 dark:text-gray-300">
                 Monorepos are hot right now, especially among Web developers. We
                 created this resource to help developers{' '}
-                <mark className="px-1 bg-yellow-500 rounded-md">
+                <mark className="rounded-md bg-yellow-500 px-1">
                   understand what monorepos are
                 </mark>
                 ,{' '}
-                <mark className="px-1 bg-yellow-500 rounded-md">
+                <mark className="rounded-md bg-yellow-500 px-1">
                   what benefits
                 </mark>
                 they can bring, and the{' '}
-                <mark className="px-1 bg-yellow-500 rounded-md">
+                <mark className="rounded-md bg-yellow-500 px-1">
                   tools available
                 </mark>{' '}
                 to make monorepo development delightful.
@@ -58,7 +58,7 @@ export function Introduction() {
                   href="https://github.com/nrwl/monorepo.tools?utm_source=monorepo.tools"
                   target="_blank"
                   rel="noreferrer"
-                  className="px-1 border-b border-yellow-500 hover:bg-yellow-500 hover:text-gray-800 transition hover:rounded"
+                  className="border-b border-yellow-500 px-1 transition hover:rounded hover:bg-yellow-500 hover:text-gray-800"
                   title="Contribute to monorepo.tools!"
                 >
                   we welcome pull requests if we got something wrong!
@@ -70,7 +70,7 @@ export function Introduction() {
                   href="https://bazel.build/?utm_source=monorepo.tools"
                   rel="noreferrer"
                   target="_blank"
-                  className="border-b border-yellow-500 hover:bg-yellow-500 hover:text-gray-800 transition hover:rounded"
+                  className="border-b border-yellow-500 transition hover:rounded hover:bg-yellow-500 hover:text-gray-800"
                 >
                   Bazel (by Google)
                 </a>
@@ -79,7 +79,7 @@ export function Introduction() {
                   rel="noreferrer"
                   target="_blank"
                   href="https://microsoft.github.io/lage/?utm_source=monorepo.tools"
-                  className="border-b border-yellow-500 hover:bg-yellow-500 hover:text-gray-800 transition hover:rounded"
+                  className="border-b border-yellow-500 transition hover:rounded hover:bg-yellow-500 hover:text-gray-800"
                 >
                   Lage (by Microsoft)
                 </a>
@@ -88,7 +88,7 @@ export function Introduction() {
                   rel="noreferrer"
                   target="_blank"
                   href="https://lerna.js.org/?utm_source=monorepo.tools"
-                  className="border-b border-yellow-500 hover:bg-yellow-500 hover:text-gray-800 transition hover:rounded"
+                  className="border-b border-yellow-500 transition hover:rounded hover:bg-yellow-500 hover:text-gray-800"
                 >
                   Lerna
                 </a>
@@ -97,7 +97,7 @@ export function Introduction() {
                   href="https://nx.dev/?utm_source=monorepo.tools"
                   rel="noreferrer"
                   target="_blank"
-                  className="border-b border-yellow-500 hover:bg-yellow-500 hover:text-gray-800 transition hover:rounded"
+                  className="border-b border-yellow-500 transition hover:rounded hover:bg-yellow-500 hover:text-gray-800"
                 >
                   Nx (by Nrwl)
                 </a>
@@ -106,7 +106,7 @@ export function Introduction() {
                   rel="noreferrer"
                   target="_blank"
                   href="https://rushstack.io/?utm_source=monorepo.tools"
-                  className="border-b border-yellow-500 hover:bg-yellow-500 hover:text-gray-800 transition hover:rounded"
+                  className="border-b border-yellow-500 transition hover:rounded hover:bg-yellow-500 hover:text-gray-800"
                 >
                   Rush (by Microsoft)
                 </a>
@@ -115,7 +115,7 @@ export function Introduction() {
                   rel="noreferrer"
                   target="_blank"
                   href="https://turborepo.org/?utm_source=monorepo.tools"
-                  className="border-b border-yellow-500 hover:bg-yellow-500 hover:text-gray-800 transition hover:rounded"
+                  className="border-b border-yellow-500 transition hover:rounded hover:bg-yellow-500 hover:text-gray-800"
                 >
                   Turborepo (by Vercel)
                 </a>
@@ -124,7 +124,7 @@ export function Introduction() {
               </p>
             </div>
             <svg
-              className="mt-16 mx-auto w-2/3 h-auto antialiased text-slate-800 dark:text-white"
+              className="mx-auto mt-16 h-auto w-2/3 text-slate-800 antialiased dark:text-white"
               viewBox="0 0 340 340"
               fill="currentColor"
               xmlns="http://www.w3.org/2000/svg"
@@ -152,11 +152,11 @@ export function Introduction() {
       </article>
 
       {/* Overlapping cards */}
-      <section className="-mt-28 max-w-7xl mx-auto relative z-10 pb-32 px-4 sm:px-6 lg:px-8">
+      <section className="relative z-10 mx-auto -mt-28 max-w-7xl px-4 pb-32 sm:px-6 lg:px-8">
         <div className="grid grid-cols-1 gap-y-20 lg:grid-cols-3 lg:gap-y-0 lg:gap-x-8">
           {/*LINKS*/}
-          <div className="flex flex-col bg-slate-100 dark:bg-slate-700 rounded-2xl shadow-xl">
-            <div className="flex-1 relative pt-16 px-6 pb-8 md:px-8">
+          <div className="flex flex-col rounded-2xl bg-slate-100 shadow-xl dark:bg-slate-700">
+            <div className="relative flex-1 px-6 pt-16 pb-8 md:px-8">
               <h2 className="text-xl font-semibold text-gray-800 dark:text-gray-200">
                 What is a monorepo
               </h2>
@@ -164,7 +164,7 @@ export function Introduction() {
                 Let's start with a common unsterstanding of what a Monorepo is.
               </p>
             </div>
-            <div className="p-6 bg-slate-200 dark:bg-slate-900 rounded-bl-2xl rounded-br-2xl md:px-8">
+            <div className="rounded-bl-2xl rounded-br-2xl bg-slate-200 p-6 dark:bg-slate-900 md:px-8">
               <a
                 href="#what-is-a-monorepo"
                 title="What is a monorepo?"
@@ -174,8 +174,8 @@ export function Introduction() {
               </a>
             </div>
           </div>
-          <div className="flex flex-col bg-slate-100 dark:bg-slate-700 rounded-2xl shadow-xl">
-            <div className="flex-1 relative pt-16 px-6 pb-8 md:px-8">
+          <div className="flex flex-col rounded-2xl bg-slate-100 shadow-xl dark:bg-slate-700">
+            <div className="relative flex-1 px-6 pt-16 pb-8 md:px-8">
               <h2 className="text-xl font-medium text-gray-800 dark:text-gray-200">
                 Why a monorepo
               </h2>
@@ -183,7 +183,7 @@ export function Introduction() {
                 What are the situations solved by monorepos.
               </p>
             </div>
-            <div className="p-6 bg-slate-200 dark:bg-slate-900 rounded-bl-2xl rounded-br-2xl md:px-8">
+            <div className="rounded-bl-2xl rounded-br-2xl bg-slate-200 p-6 dark:bg-slate-900 md:px-8">
               <a
                 href="#why-a-monorepo"
                 title="Why using a monorepo?"
@@ -193,8 +193,8 @@ export function Introduction() {
               </a>
             </div>
           </div>
-          <div className="flex flex-col bg-slate-100 dark:bg-slate-700 rounded-2xl shadow-xl">
-            <div className="flex-1 relative pt-16 px-6 pb-8 md:px-8">
+          <div className="flex flex-col rounded-2xl bg-slate-100 shadow-xl dark:bg-slate-700">
+            <div className="relative flex-1 px-6 pt-16 pb-8 md:px-8">
               <h2 className="text-xl font-medium text-gray-800 dark:text-gray-200">
                 Features of a monorepo
               </h2>
@@ -202,7 +202,7 @@ export function Introduction() {
                 What to expect from a monorepo tool
               </p>
             </div>
-            <div className="p-6 bg-slate-200 dark:bg-slate-900 rounded-bl-2xl rounded-br-2xl md:px-8">
+            <div className="rounded-bl-2xl rounded-br-2xl bg-slate-200 p-6 dark:bg-slate-900 md:px-8">
               <a
                 href="#monorepo-features"
                 title="What are monorepo features?"

--- a/libs/website/ui-home/src/lib/monolith-callout.tsx
+++ b/libs/website/ui-home/src/lib/monolith-callout.tsx
@@ -1,9 +1,9 @@
 export function MonolithCallout() {
   return (
     <article className="bg-slate-50 dark:bg-slate-800">
-      <div className="max-w-7xl mx-auto py-16 px-4 sm:px-6 lg:px-8">
-        <div className="bg-slate-100 dark:bg-slate-900 rounded-lg shadow-xl overflow-hidden">
-          <div className="pt-10 pb-12 px-6 sm:pt-16 sm:px-16 lg:py-16 lg:pr-0 xl:py-20 xl:px-20 text-center">
+      <div className="mx-auto max-w-7xl py-16 px-4 sm:px-6 lg:px-8">
+        <div className="overflow-hidden rounded-lg bg-slate-100 shadow-xl dark:bg-slate-900">
+          <div className="px-6 pt-10 pb-12 text-center sm:px-16 sm:pt-16 lg:py-16 lg:pr-0 xl:py-20 xl:px-20">
             <h1 className="text-3xl font-extrabold text-gray-900 dark:text-white sm:text-4xl">
               <span className="block text-gray-900 dark:text-white">
                 ✋ Monorepo <span aria-hidden="true">&#8800;</span>{' '}
@@ -16,7 +16,7 @@ export function MonolithCallout() {
               <a
                 title="Misconceptions about Monorepos: Monorepo != Monolith"
                 rel="nofollow"
-                className="border-b border-yellow-500 hover:bg-yellow-500 hover:text-gray-800 transition hover:rounded"
+                className="border-b border-yellow-500 transition hover:rounded hover:bg-yellow-500 hover:text-gray-800"
                 href="https://blog.nrwl.io/misconceptions-about-monorepos-monorepo-monolith-df1250d4b03c"
               >
                 &ldquo;Misconceptions about Monorepos: Monorepo !=

--- a/libs/website/ui-home/src/lib/monorepo-features-overview.tsx
+++ b/libs/website/ui-home/src/lib/monorepo-features-overview.tsx
@@ -92,28 +92,28 @@ export function MonorepoFeaturesOverview() {
   return (
     <div
       id="monorepo-features"
-      className="py-16 bg-slate-50 dark:bg-slate-800 overflow-hidden lg:py-24"
+      className="overflow-hidden bg-slate-50 py-16 dark:bg-slate-800 lg:py-24"
     >
-      <div className="relative max-w-xl mx-auto px-4 sm:px-6 lg:px-8 lg:max-w-7xl">
+      <div className="relative mx-auto max-w-xl px-4 sm:px-6 lg:max-w-7xl lg:px-8">
         <div className="relative">
-          <div className="text-center text-4xl leading-8 font-extrabold tracking-tight text-gray-900 dark:text-white sm:text-5xl group">
+          <div className="group text-center text-4xl font-extrabold leading-8 tracking-tight text-gray-900 dark:text-white sm:text-5xl">
             # Monorepo features
             <a
               aria-hidden="true"
               tabIndex={-1}
               href="#monorepo-features"
-              className="text-gray-900 dark:text-white flex inline-flex items-center"
+              className="flex inline-flex items-center text-gray-900 dark:text-white"
             >
               <LinkIcon className="ml-2 h-6 w-6 opacity-0 group-hover:opacity-100" />
             </a>
           </div>
-          <p className="mt-4 max-w-3xl mx-auto text-center text-xl text-gray-700 dark:text-gray-300">
+          <p className="mx-auto mt-4 max-w-3xl text-center text-xl text-gray-700 dark:text-gray-300">
             Everything you need to make monorepos work.
           </p>
         </div>
 
-        <nav className="px-4 py-16 sm:px-6 sm:pt-20 sm:pb-24 lg:pt-24 lg:px-8">
-          <h2 className="text-3xl font-extrabold text-gray-900 dark:text-white tracking-tight">
+        <nav className="px-4 py-16 sm:px-6 sm:pt-20 sm:pb-24 lg:px-8 lg:pt-24">
+          <h2 className="text-3xl font-extrabold tracking-tight text-gray-900 dark:text-white">
             What monorepo tools should provide
           </h2>
           <p className="mt-4 max-w-3xl text-lg text-gray-800 dark:text-gray-200">
@@ -121,20 +121,20 @@ export function MonorepoFeaturesOverview() {
             to have the right tools. As your workspace grows, the tools have to
             help you keep it fast, understandable and manageable.
           </p>
-          <div className="mt-12 grid grid-cols-1 gap-x-6 gap-y-12 lg:grid-cols-2 lg:mt-16 lg:gap-8">
+          <div className="mt-12 grid grid-cols-1 gap-x-6 gap-y-12 lg:mt-16 lg:grid-cols-2 lg:gap-8">
             {features.map((feature) => (
               <a
                 key={feature.anchor}
                 href={'#' + feature.anchor}
                 title={feature.name}
-                className="block px-4 py-5 relative overflow-hidden bg-slate-100 dark:bg-slate-900 text-gray-800 dark:text-gray-200 hover:text-gray-800 hover:dark:text-gray-800 hover:bg-yellow-500 hover:dark:bg-yellow-500 rounded-md transition group"
+                className="group relative block overflow-hidden rounded-md bg-slate-100 px-4 py-5 text-gray-800 transition hover:bg-yellow-500 hover:text-gray-800 dark:bg-slate-900 dark:text-gray-200 hover:dark:bg-yellow-500 hover:dark:text-gray-800"
               >
                 <div className="relative flex items-center space-x-4">
                   <feature.icon className="h-6 w-6" aria-hidden="true" />
                   <h3 className="flex flex-grow text-lg font-medium">
                     {feature.name}
                   </h3>
-                  <span className="absolute bottom-2.5 right-0 inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-white bg-opacity-20 capitalize">
+                  <span className="absolute bottom-2.5 right-0 inline-flex items-center rounded-full bg-white bg-opacity-20 px-2.5 py-0.5 text-xs font-medium capitalize">
                     {feature.category}
                   </span>
                 </div>

--- a/libs/website/ui-home/src/lib/monorepo-features.tsx
+++ b/libs/website/ui-home/src/lib/monorepo-features.tsx
@@ -20,27 +20,27 @@ import MonorepoToolsLogos from './monorepo-tools-logos';
 const Supported = () => (
   <span
     title="natively supported"
-    className="inline-flex items-center mr-3 rounded-full text-green-600"
+    className="mr-3 inline-flex items-center rounded-full text-green-600"
   >
-    <CheckCircleIcon className="w-5 h-5" />
+    <CheckCircleIcon className="h-5 w-5" />
     <span className="sr-only">natively supported</span>
   </span>
 );
 const NotSupported = () => (
   <span
     title="not supported"
-    className="inline-flex items-center mr-3 rounded-full text-red-600"
+    className="mr-3 inline-flex items-center rounded-full text-red-600"
   >
-    <XCircleIcon className="w-5 h-5" />
+    <XCircleIcon className="h-5 w-5" />
     <span className="sr-only">not supported</span>
   </span>
 );
 const ManualImplementation = () => (
   <span
     title="implement your own"
-    className="inline-flex items-center mr-3 rounded-full text-yellow-600"
+    className="mr-3 inline-flex items-center rounded-full text-yellow-600"
   >
-    <ExclamationCircleIcon className="w-5 h-5" />
+    <ExclamationCircleIcon className="h-5 w-5" />
     <span className="sr-only">implement your own</span>
   </span>
 );
@@ -49,22 +49,22 @@ export function MonorepoFeatures() {
   return (
     <div
       id="monorepo-tools"
-      className="py-16 bg-slate-50 dark:bg-slate-800 overflow-hidden lg:py-24"
+      className="overflow-hidden bg-slate-50 py-16 dark:bg-slate-800 lg:py-24"
     >
-      <div className="relative max-w-xl mx-auto px-4 sm:px-6 lg:px-8 lg:max-w-7xl">
+      <div className="relative mx-auto max-w-xl px-4 sm:px-6 lg:max-w-7xl lg:px-8">
         <div className="relative">
-          <div className="text-center text-4xl leading-8 font-extrabold tracking-tight text-gray-900 dark:text-white sm:text-5xl group">
+          <div className="group text-center text-4xl font-extrabold leading-8 tracking-tight text-gray-900 dark:text-white sm:text-5xl">
             # Monorepo tools
             <a
               aria-hidden="true"
               tabIndex={-1}
               href="#monorepo-tools"
-              className="text-gray-900 dark:text-white flex inline-flex items-center"
+              className="flex inline-flex items-center text-gray-900 dark:text-white"
             >
               <LinkIcon className="ml-2 h-6 w-6 opacity-0 group-hover:opacity-100" />
             </a>
           </div>
-          <p className="mt-4 max-w-3xl mx-auto text-center text-xl text-gray-700 dark:text-gray-300">
+          <p className="mx-auto mt-4 max-w-3xl text-center text-xl text-gray-700 dark:text-gray-300">
             How do they compare? let's see how each tools answer to each
             features.
           </p>
@@ -73,27 +73,27 @@ export function MonorepoFeatures() {
         <MonorepoToolsLogos />
 
         {/*FAST*/}
-        <div className="mt-24 lg:mt-32 text-2xl flex leading-loose font-boldtext-gray-800 dark:text-gray-100tracking-tight sm:text-3xl sm:leading-relaxed items-center">
+        <div className="font-boldtext-gray-800 dark:text-gray-100tracking-tight mt-24 flex items-center text-2xl leading-loose sm:text-3xl sm:leading-relaxed lg:mt-32">
           Fast
-          <div className="ml-4 flex flex-grow h-1 w-full bg-slate-100 dark:bg-slate-900 rounded" />
+          <div className="ml-4 flex h-1 w-full flex-grow rounded bg-slate-100 dark:bg-slate-900" />
         </div>
 
         {/*Local Computation Caching*/}
         <div
           id="local-computation-caching"
-          className="relative mt-16 lg:grid lg:grid-cols-2 lg:gap-12 lg:items-start"
+          className="relative mt-16 lg:grid lg:grid-cols-2 lg:items-start lg:gap-12"
         >
           <div className="relative">
-            <div className="absolute flex items-center justify-center h-10 w-10 rounded-md text-gray-800 dark:text-gray-200 rounded-md bg-slate-100 dark:bg-slate-900">
-              <DocumentDownloadIcon className="w-6 h-6" />
+            <div className="absolute flex h-10 w-10 items-center justify-center rounded-md rounded-md bg-slate-100 text-gray-800 dark:bg-slate-900 dark:text-gray-200">
+              <DocumentDownloadIcon className="h-6 w-6" />
             </div>
-            <div className="ml-16 text-xl font-medium text-gray-800 dark:text-gray-200 sm:text-2xl sm:leading-relaxed group">
+            <div className="group ml-16 text-xl font-medium text-gray-800 dark:text-gray-200 sm:text-2xl sm:leading-relaxed">
               Local computation caching
               <a
                 aria-hidden="true"
                 tabIndex={-1}
                 href="#local-computation-caching"
-                className="text-gray-900 dark:text-white flex inline-flex items-center"
+                className="flex inline-flex items-center text-gray-900 dark:text-white"
               >
                 <LinkIcon className="ml-2 h-6 w-6 opacity-0 group-hover:opacity-100" />
               </a>
@@ -117,10 +117,10 @@ export function MonorepoFeatures() {
           </div>
 
           {/* (alphabetical order) */}
-          <dl className="mt-12 md:mt-0 space-y-6">
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+          <dl className="mt-12 space-y-6 md:mt-0">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported /> Bazel
                 </p>
               </dt>
@@ -128,9 +128,9 @@ export function MonorepoFeatures() {
                 Bazel supports it.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported /> Lage
                 </p>
               </dt>
@@ -138,9 +138,9 @@ export function MonorepoFeatures() {
                 Lage supports it.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <NotSupported /> Lerna
                 </p>
               </dt>
@@ -149,9 +149,9 @@ export function MonorepoFeatures() {
                 scratch.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported /> Nx
                 </p>
               </dt>
@@ -164,9 +164,9 @@ export function MonorepoFeatures() {
                 ).
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported /> Rush
                 </p>
               </dt>
@@ -175,9 +175,9 @@ export function MonorepoFeatures() {
                 files more quickly.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported /> Turborepo
                 </p>
               </dt>
@@ -191,19 +191,19 @@ export function MonorepoFeatures() {
         {/*Local task orchestration*/}
         <div
           id="local-task-orchestration"
-          className="relative mt-16 lg:grid lg:grid-cols-2 lg:gap-12 lg:items-start"
+          className="relative mt-16 lg:grid lg:grid-cols-2 lg:items-start lg:gap-12"
         >
           <div className="relative">
-            <div className="absolute flex items-center justify-center h-10 w-10 rounded-md text-gray-800 dark:text-gray-200 rounded-md bg-slate-100 dark:bg-slate-900">
-              <SwitchVerticalIcon className="w-6 h-6" />
+            <div className="absolute flex h-10 w-10 items-center justify-center rounded-md rounded-md bg-slate-100 text-gray-800 dark:bg-slate-900 dark:text-gray-200">
+              <SwitchVerticalIcon className="h-6 w-6" />
             </div>
-            <div className="ml-16 text-xl font-medium text-gray-800 dark:text-gray-200 sm:text-2xl sm:leading-relaxed group">
+            <div className="group ml-16 text-xl font-medium text-gray-800 dark:text-gray-200 sm:text-2xl sm:leading-relaxed">
               Local task orchestration
               <a
                 aria-hidden="true"
                 tabIndex={-1}
                 href="#local-task-orchestration"
-                className="text-gray-900 dark:text-white flex inline-flex items-center"
+                className="flex inline-flex items-center text-gray-900 dark:text-white"
               >
                 <LinkIcon className="ml-2 h-6 w-6 opacity-0 group-hover:opacity-100" />
               </a>
@@ -226,10 +226,10 @@ export function MonorepoFeatures() {
             </div>
           </div>
 
-          <dl className="mt-12 md:mt-0 space-y-6">
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+          <dl className="mt-12 space-y-6 md:mt-0">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported /> Bazel
                 </p>
               </dt>
@@ -237,9 +237,9 @@ export function MonorepoFeatures() {
                 Bazel supports it.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported /> Lage
                 </p>
               </dt>
@@ -247,9 +247,9 @@ export function MonorepoFeatures() {
                 Lage supports it.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported /> Lerna
                 </p>
               </dt>
@@ -260,9 +260,9 @@ export function MonorepoFeatures() {
                 more idle time.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported /> Nx
                 </p>
               </dt>
@@ -270,9 +270,9 @@ export function MonorepoFeatures() {
                 Nx supports it.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported /> Rush
                 </p>
               </dt>
@@ -281,9 +281,9 @@ export function MonorepoFeatures() {
                 script or as separate "phases" such as build, test, etc.
               </dd>
             </div>{' '}
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported /> Turborepo
                 </p>
               </dt>
@@ -297,19 +297,19 @@ export function MonorepoFeatures() {
         {/*Distributed Computation Caching*/}
         <div
           id="distributed-computation-caching"
-          className="relative mt-16 lg:grid lg:grid-cols-2 lg:gap-12 lg:items-start"
+          className="relative mt-16 lg:grid lg:grid-cols-2 lg:items-start lg:gap-12"
         >
           <div className="relative">
-            <div className="absolute flex items-center justify-center h-10 w-10 rounded-md text-gray-800 dark:text-gray-200 rounded-md bg-slate-100 dark:bg-slate-900">
-              <CloudDownloadIcon className="w-6 h-6" />
+            <div className="absolute flex h-10 w-10 items-center justify-center rounded-md rounded-md bg-slate-100 text-gray-800 dark:bg-slate-900 dark:text-gray-200">
+              <CloudDownloadIcon className="h-6 w-6" />
             </div>
-            <div className="ml-16 text-xl font-medium text-gray-800 dark:text-gray-200 sm:text-2xl sm:leading-relaxed group">
+            <div className="group ml-16 text-xl font-medium text-gray-800 dark:text-gray-200 sm:text-2xl sm:leading-relaxed">
               Distributed computation caching
               <a
                 aria-hidden="true"
                 tabIndex={-1}
                 href="#distributed-computation-caching"
-                className="text-gray-900 dark:text-white flex inline-flex items-center"
+                className="flex inline-flex items-center text-gray-900 dark:text-white"
               >
                 <LinkIcon className="ml-2 h-6 w-6 opacity-0 group-hover:opacity-100" />
               </a>
@@ -332,10 +332,10 @@ export function MonorepoFeatures() {
             </div>
           </div>
 
-          <dl className="mt-12 md:mt-0 space-y-6">
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+          <dl className="mt-12 space-y-6 md:mt-0">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported /> Bazel
                 </p>
               </dt>
@@ -343,9 +343,9 @@ export function MonorepoFeatures() {
                 Bazel supports it.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported /> Lage
                 </p>
               </dt>
@@ -353,9 +353,9 @@ export function MonorepoFeatures() {
                 Lage supports it.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <NotSupported /> Lerna
                 </p>
               </dt>
@@ -363,9 +363,9 @@ export function MonorepoFeatures() {
                 Lerna cannot reuse computation across machines.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported /> Nx
                 </p>
               </dt>
@@ -373,9 +373,9 @@ export function MonorepoFeatures() {
                 Nx supports it.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported /> Rush
                 </p>
               </dt>
@@ -384,9 +384,9 @@ export function MonorepoFeatures() {
                 plugin API allowing custom cache providers.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported /> Turborepo
                 </p>
               </dt>
@@ -400,19 +400,19 @@ export function MonorepoFeatures() {
         {/*Distributed Task Execution*/}
         <div
           id="distributed-task-execution"
-          className="relative mt-16 lg:grid lg:grid-cols-2 lg:gap-12 lg:items-start"
+          className="relative mt-16 lg:grid lg:grid-cols-2 lg:items-start lg:gap-12"
         >
           <div className="relative">
-            <div className="absolute flex items-center justify-center h-10 w-10 rounded-md text-gray-800 dark:text-gray-200 rounded-md bg-slate-100 dark:bg-slate-900">
-              <CollectionIcon className="w-6 h-6" />
+            <div className="absolute flex h-10 w-10 items-center justify-center rounded-md rounded-md bg-slate-100 text-gray-800 dark:bg-slate-900 dark:text-gray-200">
+              <CollectionIcon className="h-6 w-6" />
             </div>
-            <div className="ml-16 text-xl font-medium text-gray-800 dark:text-gray-200 sm:text-2xl sm:leading-relaxed group">
+            <div className="group ml-16 text-xl font-medium text-gray-800 dark:text-gray-200 sm:text-2xl sm:leading-relaxed">
               Distributed task execution
               <a
                 aria-hidden="true"
                 tabIndex={-1}
                 href="#distributed-task-execution"
-                className="text-gray-900 dark:text-white flex inline-flex items-center"
+                className="flex inline-flex items-center text-gray-900 dark:text-white"
               >
                 <LinkIcon className="ml-2 h-6 w-6 opacity-0 group-hover:opacity-100" />
               </a>
@@ -435,10 +435,10 @@ export function MonorepoFeatures() {
             </div>
           </div>
 
-          <dl className="mt-12 md:mt-0 space-y-6">
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+          <dl className="mt-12 space-y-6 md:mt-0">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported /> Bazel
                 </p>
               </dt>
@@ -448,9 +448,9 @@ export function MonorepoFeatures() {
                 difficult to set up.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <NotSupported /> Lage
                 </p>
               </dt>
@@ -458,9 +458,9 @@ export function MonorepoFeatures() {
                 Lage doesn't support it.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <NotSupported /> Lerna
                 </p>
               </dt>
@@ -468,9 +468,9 @@ export function MonorepoFeatures() {
                 Lerna doesn't support it.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported /> Nx
                 </p>
               </dt>
@@ -479,9 +479,9 @@ export function MonorepoFeatures() {
                 be turned on with a small configuration change.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <ManualImplementation /> Rush
                 </p>
               </dt>
@@ -490,9 +490,9 @@ export function MonorepoFeatures() {
                 Microsoft's BuildXL accelerator.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <NotSupported /> Turborepo
                 </p>
               </dt>
@@ -506,19 +506,19 @@ export function MonorepoFeatures() {
         {/*Transparent Remote Execution*/}
         <div
           id="transparent-remote-execution"
-          className="relative mt-16 lg:grid lg:grid-cols-2 lg:gap-12 lg:items-start"
+          className="relative mt-16 lg:grid lg:grid-cols-2 lg:items-start lg:gap-12"
         >
           <div className="relative">
-            <div className="absolute flex items-center justify-center h-10 w-10 rounded-md text-gray-800 dark:text-gray-200 rounded-md bg-slate-100 dark:bg-slate-900">
-              <ServerIcon className="w-6 h-6" />
+            <div className="absolute flex h-10 w-10 items-center justify-center rounded-md rounded-md bg-slate-100 text-gray-800 dark:bg-slate-900 dark:text-gray-200">
+              <ServerIcon className="h-6 w-6" />
             </div>
-            <div className="ml-16 text-xl font-medium text-gray-800 dark:text-gray-200 sm:text-2xl sm:leading-relaxed group">
+            <div className="group ml-16 text-xl font-medium text-gray-800 dark:text-gray-200 sm:text-2xl sm:leading-relaxed">
               Transparent remote execution
               <a
                 aria-hidden="true"
                 tabIndex={-1}
                 href="#transparent-remote-execution"
-                className="text-gray-900 dark:text-white flex inline-flex items-center"
+                className="flex inline-flex items-center text-gray-900 dark:text-white"
               >
                 <LinkIcon className="ml-2 h-6 w-6 opacity-0 group-hover:opacity-100" />
               </a>
@@ -530,10 +530,10 @@ export function MonorepoFeatures() {
             </p>
           </div>
 
-          <dl className="mt-12 md:mt-0 space-y-6">
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+          <dl className="mt-12 space-y-6 md:mt-0">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported /> Bazel
                 </p>
               </dt>
@@ -541,9 +541,9 @@ export function MonorepoFeatures() {
                 This is Bazel's biggest differentiator.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <NotSupported /> Lage
                 </p>
               </dt>
@@ -551,9 +551,9 @@ export function MonorepoFeatures() {
                 Lage doesn't support it.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <NotSupported /> Lerna
                 </p>
               </dt>
@@ -561,9 +561,9 @@ export function MonorepoFeatures() {
                 Lerna doesn't support it.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <NotSupported /> Nx
                 </p>
               </dt>
@@ -571,9 +571,9 @@ export function MonorepoFeatures() {
                 Nx doesn't support it.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <NotSupported /> Rush
                 </p>
               </dt>
@@ -581,9 +581,9 @@ export function MonorepoFeatures() {
                 Rush doesn't support it.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <NotSupported /> Turborepo
                 </p>
               </dt>
@@ -597,19 +597,19 @@ export function MonorepoFeatures() {
         {/*Affected*/}
         <div
           id="detecting-affected-projects-packages"
-          className="relative mt-16 lg:grid lg:grid-cols-2 lg:gap-12 lg:items-start"
+          className="relative mt-16 lg:grid lg:grid-cols-2 lg:items-start lg:gap-12"
         >
           <div className="relative">
-            <div className="absolute flex items-center justify-center h-10 w-10 rounded-md text-gray-800 dark:text-gray-200 rounded-md bg-slate-100 dark:bg-slate-900">
-              <LightBulbIcon className="w-6 h-6" />
+            <div className="absolute flex h-10 w-10 items-center justify-center rounded-md rounded-md bg-slate-100 text-gray-800 dark:bg-slate-900 dark:text-gray-200">
+              <LightBulbIcon className="h-6 w-6" />
             </div>
-            <div className="ml-16 text-xl font-medium text-gray-800 dark:text-gray-200 sm:text-2xl sm:leading-relaxed group">
+            <div className="group ml-16 text-xl font-medium text-gray-800 dark:text-gray-200 sm:text-2xl sm:leading-relaxed">
               Detecting affected projects/packages
               <a
                 aria-hidden="true"
                 tabIndex={-1}
                 href="#detecting-affected-projects-packages"
-                className="text-gray-900 dark:text-white flex inline-flex items-center"
+                className="flex inline-flex items-center text-gray-900 dark:text-white"
               >
                 <LinkIcon className="ml-2 h-6 w-6 opacity-0 group-hover:opacity-100" />
               </a>
@@ -631,10 +631,10 @@ export function MonorepoFeatures() {
             </div>
           </div>
 
-          <dl className="mt-12 md:mt-0 space-y-6">
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+          <dl className="mt-12 space-y-6 md:mt-0">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <ManualImplementation /> Bazel
                 </p>
               </dt>
@@ -643,9 +643,9 @@ export function MonorepoFeatures() {
                 making it possible to write such functionality youself.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported /> Lage
                 </p>
               </dt>
@@ -653,9 +653,9 @@ export function MonorepoFeatures() {
                 Lage supports it.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported /> Lerna
                 </p>
               </dt>
@@ -663,9 +663,9 @@ export function MonorepoFeatures() {
                 Lerna supports it.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported /> Nx
                 </p>
               </dt>
@@ -674,9 +674,9 @@ export function MonorepoFeatures() {
                 files changed but also at the nature of the change.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported /> Rush
                 </p>
               </dt>
@@ -686,9 +686,9 @@ export function MonorepoFeatures() {
                 PackageChangeAnalyzer API for automation scenarios.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported /> Turborepo
                 </p>
               </dt>
@@ -700,27 +700,27 @@ export function MonorepoFeatures() {
         </div>
 
         {/*UNDERSTANDABLE*/}
-        <div className="mt-24 lg:mt-32 text-2xl flex leading-loose font-boldtext-gray-800 dark:text-gray-100tracking-tight sm:text-3xl sm:leading-relaxed items-center">
+        <div className="font-boldtext-gray-800 dark:text-gray-100tracking-tight mt-24 flex items-center text-2xl leading-loose sm:text-3xl sm:leading-relaxed lg:mt-32">
           Understandable
-          <div className="ml-4 flex flex-grow h-1 w-full bg-slate-100 dark:bg-slate-900 rounded" />
+          <div className="ml-4 flex h-1 w-full flex-grow rounded bg-slate-100 dark:bg-slate-900" />
         </div>
 
         {/*Workspace analysis*/}
         <div
           id="workspace-analysis"
-          className="relative mt-16 lg:grid lg:grid-cols-2 lg:gap-12 lg:items-start"
+          className="relative mt-16 lg:grid lg:grid-cols-2 lg:items-start lg:gap-12"
         >
           <div className="relative">
-            <div className="absolute flex items-center justify-center h-10 w-10 rounded-md text-gray-800 dark:text-gray-200 rounded-md bg-slate-100 dark:bg-slate-900">
-              <PresentationChartLineIcon className="w-6 h-6" />
+            <div className="absolute flex h-10 w-10 items-center justify-center rounded-md rounded-md bg-slate-100 text-gray-800 dark:bg-slate-900 dark:text-gray-200">
+              <PresentationChartLineIcon className="h-6 w-6" />
             </div>
-            <div className="ml-16 text-xl font-medium text-gray-800 dark:text-gray-200 sm:text-2xl sm:leading-relaxed group">
+            <div className="group ml-16 text-xl font-medium text-gray-800 dark:text-gray-200 sm:text-2xl sm:leading-relaxed">
               Workspace analysis
               <a
                 aria-hidden="true"
                 tabIndex={-1}
                 href="#workspace-analysis"
-                className="text-gray-900 dark:text-white flex inline-flex items-center"
+                className="flex inline-flex items-center text-gray-900 dark:text-white"
               >
                 <LinkIcon className="ml-2 h-6 w-6 opacity-0 group-hover:opacity-100" />
               </a>
@@ -742,10 +742,10 @@ export function MonorepoFeatures() {
             </div>
           </div>
 
-          <dl className="mt-12 md:mt-0 space-y-6">
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+          <dl className="mt-12 space-y-6 md:mt-0">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <ManualImplementation /> Bazel
                 </p>
               </dt>
@@ -755,9 +755,9 @@ export function MonorepoFeatures() {
                 BUILD files.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported /> Lage
                 </p>
               </dt>
@@ -765,9 +765,9 @@ export function MonorepoFeatures() {
                 Lage analyses package.json files.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported /> Lerna
                 </p>
               </dt>
@@ -775,9 +775,9 @@ export function MonorepoFeatures() {
                 Lerna analyses package.json files.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported /> Nx
                 </p>
               </dt>
@@ -787,9 +787,9 @@ export function MonorepoFeatures() {
                 support other platforms (e.g, Go, Java, Rust).
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported /> Rush
                 </p>
               </dt>
@@ -799,9 +799,9 @@ export function MonorepoFeatures() {
                 the monorepo by optionally creating "rig packages."
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported /> Turborepo
                 </p>
               </dt>
@@ -815,19 +815,19 @@ export function MonorepoFeatures() {
         {/*Dependency Graph Visualization*/}
         <div
           id="dependency-graph-visualization"
-          className="relative mt-16 lg:grid lg:grid-cols-2 lg:gap-12 lg:items-start"
+          className="relative mt-16 lg:grid lg:grid-cols-2 lg:items-start lg:gap-12"
         >
           <div className="relative">
-            <div className="absolute flex items-center justify-center h-10 w-10 rounded-md text-gray-800 dark:text-gray-200 rounded-md bg-slate-100 dark:bg-slate-900">
-              <PresentationChartLineIcon className="w-6 h-6" />
+            <div className="absolute flex h-10 w-10 items-center justify-center rounded-md rounded-md bg-slate-100 text-gray-800 dark:bg-slate-900 dark:text-gray-200">
+              <PresentationChartLineIcon className="h-6 w-6" />
             </div>
-            <div className="ml-16 text-xl font-medium text-gray-800 dark:text-gray-200 sm:text-2xl sm:leading-relaxed group">
+            <div className="group ml-16 text-xl font-medium text-gray-800 dark:text-gray-200 sm:text-2xl sm:leading-relaxed">
               Dependency graph visualization
               <a
                 aria-hidden="true"
                 tabIndex={-1}
                 href="#dependency-graph-visualization"
-                className="text-gray-900 dark:text-white flex inline-flex items-center"
+                className="flex inline-flex items-center text-gray-900 dark:text-white"
               >
                 <LinkIcon className="ml-2 h-6 w-6 opacity-0 group-hover:opacity-100" />
               </a>
@@ -852,10 +852,10 @@ export function MonorepoFeatures() {
             </div>
           </div>
 
-          <dl className="mt-12 md:mt-0 space-y-6">
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+          <dl className="mt-12 space-y-6 md:mt-0">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported /> Bazel
                 </p>
               </dt>
@@ -864,9 +864,9 @@ export function MonorepoFeatures() {
                 filter out node you are not interested in.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <ManualImplementation /> Lage
                 </p>
               </dt>
@@ -875,9 +875,9 @@ export function MonorepoFeatures() {
                 your own.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <ManualImplementation /> Lerna
                 </p>
               </dt>
@@ -886,9 +886,9 @@ export function MonorepoFeatures() {
                 your own.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported /> Nx
                 </p>
               </dt>
@@ -897,9 +897,9 @@ export function MonorepoFeatures() {
                 and explore large workspaces.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <ManualImplementation /> Rush
                 </p>
               </dt>
@@ -908,9 +908,9 @@ export function MonorepoFeatures() {
                 your own.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported /> Turborepo
                 </p>
               </dt>
@@ -923,27 +923,27 @@ export function MonorepoFeatures() {
         </div>
 
         {/*MANAGEMENT*/}
-        <div className="mt-24 lg:mt-32 text-2xl flex leading-loose font-boldtext-gray-800 dark:text-gray-100tracking-tight sm:text-3xl sm:leading-relaxed items-center">
+        <div className="font-boldtext-gray-800 dark:text-gray-100tracking-tight mt-24 flex items-center text-2xl leading-loose sm:text-3xl sm:leading-relaxed lg:mt-32">
           Managable
-          <div className="ml-4 flex flex-grow h-1 w-full bg-slate-100 dark:bg-slate-900 rounded" />
+          <div className="ml-4 flex h-1 w-full flex-grow rounded bg-slate-100 dark:bg-slate-900" />
         </div>
 
         {/*Code Sharing*/}
         <div
           id="source-code-sharing"
-          className="relative mt-16 lg:grid lg:grid-cols-2 lg:gap-12 lg:items-start"
+          className="relative mt-16 lg:grid lg:grid-cols-2 lg:items-start lg:gap-12"
         >
           <div className="relative">
-            <div className="absolute flex items-center justify-center h-10 w-10 rounded-md text-gray-800 dark:text-gray-200 rounded-md bg-slate-100 dark:bg-slate-900">
-              <CodeIcon className="w-6 h-6" />
+            <div className="absolute flex h-10 w-10 items-center justify-center rounded-md rounded-md bg-slate-100 text-gray-800 dark:bg-slate-900 dark:text-gray-200">
+              <CodeIcon className="h-6 w-6" />
             </div>
-            <div className="ml-16 text-xl font-medium text-gray-800 dark:text-gray-200 sm:text-2xl sm:leading-relaxed group">
+            <div className="group ml-16 text-xl font-medium text-gray-800 dark:text-gray-200 sm:text-2xl sm:leading-relaxed">
               Source code sharing
               <a
                 aria-hidden="true"
                 tabIndex={-1}
                 href="#source-code-sharing"
-                className="text-gray-900 dark:text-white flex inline-flex items-center"
+                className="flex inline-flex items-center text-gray-900 dark:text-white"
               >
                 <LinkIcon className="ml-2 h-6 w-6 opacity-0 group-hover:opacity-100" />
               </a>
@@ -963,10 +963,10 @@ export function MonorepoFeatures() {
               />
             </div>
           </div>
-          <dl className="mt-12 md:mt-0 space-y-6">
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+          <dl className="mt-12 space-y-6 md:mt-0">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported />
                   Bazel
                 </p>
@@ -977,9 +977,9 @@ export function MonorepoFeatures() {
                 sharing without hurting dev ergonomics.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported />
                   Lage
                 </p>
@@ -988,9 +988,9 @@ export function MonorepoFeatures() {
                 Lage supports it. Only npm packages can be shared.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported />
                   Lerna
                 </p>
@@ -999,9 +999,9 @@ export function MonorepoFeatures() {
                 Lerna supports it. Only npm packages can be shared.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported />
                   Nx
                 </p>
@@ -1013,9 +1013,9 @@ export function MonorepoFeatures() {
                 ergonomics.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported />
                   Rush
                 </p>
@@ -1028,9 +1028,9 @@ export function MonorepoFeatures() {
                 "packlets" offer a lightweight alternative.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported />
                   Turborepo
                 </p>
@@ -1045,19 +1045,19 @@ export function MonorepoFeatures() {
         {/*Consistent Tooling*/}
         <div
           id="consistent-tooling"
-          className="relative mt-16 lg:grid lg:grid-cols-2 lg:gap-12 lg:items-start"
+          className="relative mt-16 lg:grid lg:grid-cols-2 lg:items-start lg:gap-12"
         >
           <div className="relative">
-            <div className="absolute flex items-center justify-center h-10 w-10 rounded-md text-gray-800 dark:text-gray-200 rounded-md bg-slate-100 dark:bg-slate-900">
-              <TerminalIcon className="w-6 h-6" />
+            <div className="absolute flex h-10 w-10 items-center justify-center rounded-md rounded-md bg-slate-100 text-gray-800 dark:bg-slate-900 dark:text-gray-200">
+              <TerminalIcon className="h-6 w-6" />
             </div>
-            <div className="ml-16 text-xl font-medium text-gray-800 dark:text-gray-200 sm:text-2xl sm:leading-relaxed group">
+            <div className="group ml-16 text-xl font-medium text-gray-800 dark:text-gray-200 sm:text-2xl sm:leading-relaxed">
               Consistent tooling
               <a
                 aria-hidden="true"
                 tabIndex={-1}
                 href="#consistent-tooling"
-                className="text-gray-900 dark:text-white flex inline-flex items-center"
+                className="flex inline-flex items-center text-gray-900 dark:text-white"
               >
                 <LinkIcon className="ml-2 h-6 w-6 opacity-0 group-hover:opacity-100" />
               </a>
@@ -1079,10 +1079,10 @@ export function MonorepoFeatures() {
               />
             </div>
           </div>
-          <dl className="mt-12 md:mt-0 space-y-6">
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+          <dl className="mt-12 space-y-6 md:mt-0">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported />
                   Bazel
                 </p>
@@ -1092,9 +1092,9 @@ export function MonorepoFeatures() {
                 and frameworks.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <NotSupported />
                   Lage
                 </p>
@@ -1103,9 +1103,9 @@ export function MonorepoFeatures() {
                 Lage can only run npm scripts.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <NotSupported />
                   Lerna
                 </p>
@@ -1114,9 +1114,9 @@ export function MonorepoFeatures() {
                 Lerna can only run npm scripts.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported />
                   Nx
                 </p>
@@ -1126,9 +1126,9 @@ export function MonorepoFeatures() {
                 but can be extended to invoke other tools (e.g., Gradle).
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <NotSupported />
                   Rush
                 </p>
@@ -1140,9 +1140,9 @@ export function MonorepoFeatures() {
                 required prerequisite for monorepo developers.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <NotSupported />
                   Turborepo
                 </p>
@@ -1157,19 +1157,19 @@ export function MonorepoFeatures() {
         {/*Code Generation*/}
         <div
           id="code-generation"
-          className="relative mt-16 lg:grid lg:grid-cols-2 lg:gap-12 lg:items-start"
+          className="relative mt-16 lg:grid lg:grid-cols-2 lg:items-start lg:gap-12"
         >
           <div className="relative">
-            <div className="absolute flex items-center justify-center h-10 w-10 rounded-md text-gray-800 dark:text-gray-200 rounded-md bg-slate-100 dark:bg-slate-900">
-              <CogIcon className="w-6 h-6" />
+            <div className="absolute flex h-10 w-10 items-center justify-center rounded-md rounded-md bg-slate-100 text-gray-800 dark:bg-slate-900 dark:text-gray-200">
+              <CogIcon className="h-6 w-6" />
             </div>
-            <div className="ml-16 text-xl font-medium text-gray-800 dark:text-gray-200 sm:text-2xl sm:leading-relaxed group">
+            <div className="group ml-16 text-xl font-medium text-gray-800 dark:text-gray-200 sm:text-2xl sm:leading-relaxed">
               Code generation
               <a
                 aria-hidden="true"
                 tabIndex={-1}
                 href="#code-generation"
-                className="text-gray-900 dark:text-white flex inline-flex items-center"
+                className="flex inline-flex items-center text-gray-900 dark:text-white"
               >
                 <LinkIcon className="ml-2 h-6 w-6 opacity-0 group-hover:opacity-100" />
               </a>
@@ -1190,10 +1190,10 @@ export function MonorepoFeatures() {
             </div>
           </div>
 
-          <dl className="mt-12 md:mt-0 space-y-6">
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+          <dl className="mt-12 space-y-6 md:mt-0">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <ManualImplementation />
                   Bazel
                 </p>
@@ -1202,9 +1202,9 @@ export function MonorepoFeatures() {
                 External generators can be used.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <ManualImplementation />
                   Lage
                 </p>
@@ -1213,9 +1213,9 @@ export function MonorepoFeatures() {
                 External generators can be used.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <ManualImplementation />
                   Lerna
                 </p>
@@ -1224,9 +1224,9 @@ export function MonorepoFeatures() {
                 External generators can be used.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported />
                   Nx
                 </p>
@@ -1238,9 +1238,9 @@ export function MonorepoFeatures() {
                 be used as well.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <ManualImplementation />
                   Rush
                 </p>
@@ -1252,9 +1252,9 @@ export function MonorepoFeatures() {
                 community plugin.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <ManualImplementation />
                   Turborepo
                 </p>
@@ -1269,19 +1269,19 @@ export function MonorepoFeatures() {
         {/*Explicit Project Constrains*/}
         <div
           id="explicit-project-constrains"
-          className="relative mt-16 lg:grid lg:grid-cols-2 lg:gap-12 lg:items-start"
+          className="relative mt-16 lg:grid lg:grid-cols-2 lg:items-start lg:gap-12"
         >
           <div className="relative">
-            <div className="absolute flex items-center justify-center h-10 w-10 rounded-md text-gray-800 dark:text-gray-200 rounded-md bg-slate-100 dark:bg-slate-900">
-              <StatusOnlineIcon className="w-6 h-6" />
+            <div className="absolute flex h-10 w-10 items-center justify-center rounded-md rounded-md bg-slate-100 text-gray-800 dark:bg-slate-900 dark:text-gray-200">
+              <StatusOnlineIcon className="h-6 w-6" />
             </div>
-            <div className="ml-16 text-xl font-medium text-gray-800 dark:text-gray-200 sm:text-2xl sm:leading-relaxed group">
+            <div className="group ml-16 text-xl font-medium text-gray-800 dark:text-gray-200 sm:text-2xl sm:leading-relaxed">
               Project constraints and visibility
               <a
                 aria-hidden="true"
                 tabIndex={-1}
                 href="#explicit-project-constrains"
-                className="text-gray-900 dark:text-white flex inline-flex items-center"
+                className="flex inline-flex items-center text-gray-900 dark:text-white"
               >
                 <LinkIcon className="ml-2 h-6 w-6 opacity-0 group-hover:opacity-100" />
               </a>
@@ -1307,10 +1307,10 @@ export function MonorepoFeatures() {
             </div>
           </div>
 
-          <dl className="mt-12 md:mt-0 space-y-6">
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+          <dl className="mt-12 space-y-6 md:mt-0">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported />
                   Bazel
                 </p>
@@ -1320,9 +1320,9 @@ export function MonorepoFeatures() {
                 private from what is public, what can be shared, etc.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <ManualImplementation />
                   Lage
                 </p>
@@ -1332,9 +1332,9 @@ export function MonorepoFeatures() {
                 be used to ensure that some constraints hold.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <ManualImplementation />
                   Lerna
                 </p>
@@ -1344,9 +1344,9 @@ export function MonorepoFeatures() {
                 be used to ensure that some constraints hold.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported />
                   Nx
                 </p>
@@ -1360,9 +1360,9 @@ export function MonorepoFeatures() {
                 able to deep import into them.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported />
                   Rush
                 </p>
@@ -1373,9 +1373,9 @@ export function MonorepoFeatures() {
                 also supports version policies for NPM publishing.
               </dd>
             </div>
-            <div className="p-4 bg-slate-100 dark:bg-slate-900 rounded-md border border-slate-200 dark:border-black">
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
-                <p className="px-3 py-2 inline-flex items-center justify-center rounded-md bg-slate-50 dark:bg-slate-800 text-gray-700 dark:text-gray-300 text-sm uppercase tracking-widest">
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <ManualImplementation />
                   Turborepo
                 </p>

--- a/libs/website/ui-home/src/lib/monorepo-tools-logos.tsx
+++ b/libs/website/ui-home/src/lib/monorepo-tools-logos.tsx
@@ -28,7 +28,7 @@ const tools: { name: string; link: string }[] = [
 
 export function MonorepoToolsLogos() {
   return (
-    <div className="py-12 lg:py-16 mt-8 grid grid-cols-1 gap-0.5 md:grid-cols-6 lg:mt-16 text-3xl font-semibold">
+    <div className="mt-8 grid grid-cols-1 gap-0.5 py-12 text-3xl font-semibold md:grid-cols-6 lg:mt-16 lg:py-16">
       {tools.map((tool) => (
         <a
           key={'tool-' + tool.name}
@@ -36,7 +36,7 @@ export function MonorepoToolsLogos() {
           title={tool.name + ' on Github'}
           rel="noreferrer"
           target="_blank"
-          className="col-span-1 flex justify-center py-8 px-8 bg-slate-100 dark:bg-slate-900 hover:text-gray-800 hover:bg-yellow-500 hover:dark:bg-yellow-500 transition rounded"
+          className="col-span-1 flex justify-center rounded bg-slate-100 py-8 px-8 transition hover:bg-yellow-500 hover:text-gray-800 dark:bg-slate-900 hover:dark:bg-yellow-500"
         >
           {tool.name}
         </a>

--- a/libs/website/ui-home/src/lib/resources.tsx
+++ b/libs/website/ui-home/src/lib/resources.tsx
@@ -127,39 +127,39 @@ const books: {
 
 export function Resources() {
   return (
-    <article className="bg-slate-50 dark:bg-slate-800 pt-16 pb-20 px-4 sm:px-6 lg:pt-24 lg:pb-28 lg:px-8">
+    <article className="bg-slate-50 px-4 pt-16 pb-20 dark:bg-slate-800 sm:px-6 lg:px-8 lg:pt-24 lg:pb-28">
       <div className="relative">
         <h1
           id="monorepo-resources"
-          className="text-center text-4xl leading-8 font-extrabold tracking-tight text-gray-900 dark:text-white sm:text-5xl group"
+          className="group text-center text-4xl font-extrabold leading-8 tracking-tight text-gray-900 dark:text-white sm:text-5xl"
         >
           # Resources
           <a
             aria-hidden="true"
             tabIndex={-1}
             href="#monorepo-resources"
-            className="text-gray-900 dark:text-white flex inline-flex items-center"
+            className="flex inline-flex items-center text-gray-900 dark:text-white"
           >
             <LinkIcon className="ml-2 h-6 w-6 opacity-0 group-hover:opacity-100" />
           </a>
         </h1>
-        <p className="mt-4 max-w-3xl mx-auto text-center text-xl text-gray-700 dark:text-gray-300">
+        <p className="mx-auto mt-4 max-w-3xl text-center text-xl text-gray-700 dark:text-gray-300">
           Here is a curated list of useful videos and podcasts to go deeper or
           just see the information in another way.
         </p>
       </div>
-      <div className="mt-24 lg:mt-36 relative max-w-lg mx-auto lg:max-w-7xl">
-        <div className="max-w-2xl mx-auto">
+      <div className="relative mx-auto mt-24 max-w-lg lg:mt-36 lg:max-w-7xl">
+        <div className="mx-auto max-w-2xl">
           <h2
             id="monorepo-videos-podcasts"
-            className="text-3xl tracking-tight font-semibold text-gray-800 dark:text-gray-100 sm:text-4xl group"
+            className="group text-3xl font-semibold tracking-tight text-gray-800 dark:text-gray-100 sm:text-4xl"
           >
             Monorepo Videos & Podcasts
             <a
               aria-hidden="true"
               tabIndex={-1}
               href="#monorepo-videos-podcasts"
-              className="text-gray-900 dark:text-white flex inline-flex items-center"
+              className="flex inline-flex items-center text-gray-900 dark:text-white"
             >
               <LinkIcon className="ml-2 h-6 w-6 opacity-0 group-hover:opacity-100" />
             </a>
@@ -178,27 +178,27 @@ export function Resources() {
                   href={item.link}
                   target="_blank"
                   rel="noreferrer"
-                  className="px-1 flex items-center hover:bg-yellow-500 hover:text-gray-800 transition rounded"
+                  className="flex items-center rounded px-1 transition hover:bg-yellow-500 hover:text-gray-800"
                 >
-                  <ExternalLinkIcon className="w-5 h-5 mr-2" /> {item.name}
+                  <ExternalLinkIcon className="mr-2 h-5 w-5" /> {item.name}
                 </a>
               </li>
             ))}
           </ul>
         </div>
       </div>
-      <div className="mt-24 lg:mt-36 relative max-w-lg mx-auto lg:max-w-7xl">
-        <div className="max-w-2xl mx-auto">
+      <div className="relative mx-auto mt-24 max-w-lg lg:mt-36 lg:max-w-7xl">
+        <div className="mx-auto max-w-2xl">
           <h2
             id="monorepo-articles"
-            className="text-3xl tracking-tight font-semibold text-gray-800 dark:text-gray-100 sm:text-4xl group"
+            className="group text-3xl font-semibold tracking-tight text-gray-800 dark:text-gray-100 sm:text-4xl"
           >
             Monorepo articles
             <a
               aria-hidden="true"
               tabIndex={-1}
               href="#monorepo-articles"
-              className="text-gray-900 dark:text-white flex inline-flex items-center"
+              className="flex inline-flex items-center text-gray-900 dark:text-white"
             >
               <LinkIcon className="ml-2 h-6 w-6 opacity-0 group-hover:opacity-100" />
             </a>
@@ -217,27 +217,27 @@ export function Resources() {
                   href={item.link}
                   target="_blank"
                   rel="noreferrer"
-                  className="px-1 flex items-center hover:bg-yellow-500 hover:text-gray-800 transition rounded"
+                  className="flex items-center rounded px-1 transition hover:bg-yellow-500 hover:text-gray-800"
                 >
-                  <ExternalLinkIcon className="w-5 h-5 mr-2" /> {item.name}
+                  <ExternalLinkIcon className="mr-2 h-5 w-5" /> {item.name}
                 </a>
               </li>
             ))}
           </ul>
         </div>
       </div>
-      <div className="mt-24 lg:mt-36 relative max-w-lg mx-auto lg:max-w-7xl">
-        <div className="max-w-2xl mx-auto">
+      <div className="relative mx-auto mt-24 max-w-lg lg:mt-36 lg:max-w-7xl">
+        <div className="mx-auto max-w-2xl">
           <h2
             id="monorepo-books"
-            className="text-3xl tracking-tight font-semibold text-gray-800 dark:text-gray-100 sm:text-4xl group"
+            className="group text-3xl font-semibold tracking-tight text-gray-800 dark:text-gray-100 sm:text-4xl"
           >
             Monorepo books
             <a
               aria-hidden="true"
               tabIndex={-1}
               href="#monorepo-books"
-              className="text-gray-900 dark:text-white flex inline-flex items-center"
+              className="flex inline-flex items-center text-gray-900 dark:text-white"
             >
               <LinkIcon className="ml-2 h-6 w-6 opacity-0 group-hover:opacity-100" />
             </a>
@@ -253,23 +253,23 @@ export function Resources() {
                   href={book.link}
                   target="_blank"
                   rel="noreferrer"
-                  className="text-gray-700 dark:text-gray-300 flex p-2 hover:bg-yellow-500 hover:text-gray-800 hover:dark:text-gray-800 transition rounded-lg"
+                  className="flex rounded-lg p-2 text-gray-700 transition hover:bg-yellow-500 hover:text-gray-800 dark:text-gray-300 hover:dark:text-gray-800"
                   title={book.name}
                 >
                   <div className="space-y-4 sm:grid sm:grid-cols-3 sm:gap-6 sm:space-y-0 lg:gap-8">
-                    <div className="w-1/2 mx-auto sm:w-full sm:h-0 sm:aspect-w-3 sm:aspect-h-4">
+                    <div className="sm:aspect-w-3 sm:aspect-h-4 mx-auto w-1/2 sm:h-0 sm:w-full">
                       <img
                         loading="lazy"
-                        className="object-cover shadow-lg rounded-lg"
+                        className="rounded-lg object-cover shadow-lg"
                         src={book.imageUrl}
                         alt={book.name + ' book cover'}
                       />
                     </div>
-                    <div className="hidden sm:block sm:col-span-2">
+                    <div className="hidden sm:col-span-2 sm:block">
                       <div className="space-y-4">
-                        <div className="text-lg leading-6 font-medium space-y-1">
-                          <h3 className="block pr-6 relative">
-                            <ExternalLinkIcon className="w-5 h-5 absolute top-0 right-0" />{' '}
+                        <div className="space-y-1 text-lg font-medium leading-6">
+                          <h3 className="relative block pr-6">
+                            <ExternalLinkIcon className="absolute top-0 right-0 h-5 w-5" />{' '}
                             <span>{book.name}</span>
                           </h3>
                           <p className="text-base font-normal uppercase">
@@ -286,18 +286,18 @@ export function Resources() {
           </ul>
         </div>
       </div>
-      <div className="mt-24 lg:mt-36 relative max-w-lg mx-auto lg:max-w-7xl">
-        <div className="max-w-2xl mx-auto">
+      <div className="relative mx-auto mt-24 max-w-lg lg:mt-36 lg:max-w-7xl">
+        <div className="mx-auto max-w-2xl">
           <h2
             id="monorepo-contributors"
-            className="text-3xl tracking-tight font-semibold text-gray-800 dark:text-gray-100 sm:text-4xl group"
+            className="group text-3xl font-semibold tracking-tight text-gray-800 dark:text-gray-100 sm:text-4xl"
           >
             Contributors
             <a
               aria-hidden="true"
               tabIndex={-1}
               href="#monorepo-contributors"
-              className="text-gray-900 dark:text-white flex inline-flex items-center"
+              className="flex inline-flex items-center text-gray-900 dark:text-white"
             >
               <LinkIcon className="ml-2 h-6 w-6 opacity-0 group-hover:opacity-100" />
             </a>
@@ -311,21 +311,21 @@ export function Resources() {
               <li key={person.name}>
                 <div className="flex items-center space-x-4 lg:space-x-6">
                   <img
-                    className="w-16 h-16 rounded-full lg:w-20 lg:h-20"
+                    className="h-16 w-16 rounded-full lg:h-20 lg:w-20"
                     src={person.imageUrl}
                     alt={person.name + ' avatar'}
                   />
-                  <div className="font-medium text-lg leading-6 space-y-1">
+                  <div className="space-y-1 text-lg font-medium leading-6">
                     <h3>
                       <a
                         href={person.twitterLink}
                         target="_blank"
                         rel="noreferrer"
-                        className="px-1 flex items-center hover:bg-yellow-500 hover:text-gray-800 transition rounded"
+                        className="flex items-center rounded px-1 transition hover:bg-yellow-500 hover:text-gray-800"
                       >
                         <svg
                           aria-hidden="true"
-                          className="w-4 h-4 mr-2"
+                          className="mr-2 h-4 w-4"
                           fill="currentColor"
                           role="img"
                           viewBox="0 0 24 24"
@@ -342,11 +342,11 @@ export function Resources() {
                         href={person.githubLink}
                         target="_blank"
                         rel="noreferrer"
-                        className="px-1 flex inline-flex items-center hover:bg-yellow-500 hover:text-gray-800 transition rounded"
+                        className="flex inline-flex items-center rounded px-1 transition hover:bg-yellow-500 hover:text-gray-800"
                       >
                         <svg
                           aria-hidden="true"
-                          className="w-4 h-4 mr-2"
+                          className="mr-2 h-4 w-4"
                           fill="currentColor"
                           role="img"
                           viewBox="0 0 24 24"

--- a/libs/website/ui-home/src/lib/tools-review.tsx
+++ b/libs/website/ui-home/src/lib/tools-review.tsx
@@ -232,27 +232,27 @@ const valuesDictionary: Record<Supports, () => ReactComponentElement<any>> = {
   supported: () => (
     <span
       title="natively supported"
-      className="inline-flex items-center px-2.5 py-0.5 rounded-full text-green-600"
+      className="inline-flex items-center rounded-full px-2.5 py-0.5 text-green-600"
     >
-      <CheckCircleIcon className="w-5 h-5" />
+      <CheckCircleIcon className="h-5 w-5" />
       <span className="sr-only">natively supported</span>
     </span>
   ),
   notSupported: () => (
     <span
       title="not supported"
-      className="inline-flex items-center px-2.5 py-0.5 rounded-full text-slate-400"
+      className="inline-flex items-center rounded-full px-2.5 py-0.5 text-slate-400"
     >
-      <MinusIcon className="w-5 h-5" />
+      <MinusIcon className="h-5 w-5" />
       <span className="sr-only">not supported</span>
     </span>
   ),
   manualImplementation: () => (
     <span
       title="implement your own"
-      className="inline-flex items-center px-2.5 py-0.5 rounded-full text-yellow-600"
+      className="inline-flex items-center rounded-full px-2.5 py-0.5 text-yellow-600"
     >
-      <ExclamationCircleIcon className="w-5 h-5" />
+      <ExclamationCircleIcon className="h-5 w-5" />
       <span className="sr-only">implement your own</span>
     </span>
   ),
@@ -266,15 +266,15 @@ export function ToolsReview() {
   return (
     <div id="tools-review" className="bg-slate-50 dark:bg-slate-800">
       <div className="relative">
-        <div className="relative max-w-2xl mx-auto pt-16 px-4 text-center sm:pt-32 sm:px-6 lg:max-w-7xl lg:px-8">
-          <div className="text-4xl font-extrabold tracking-tight text-gray-900 dark:text-white sm:text-6xl group">
+        <div className="relative mx-auto max-w-2xl px-4 pt-16 text-center sm:px-6 sm:pt-32 lg:max-w-7xl lg:px-8">
+          <div className="group text-4xl font-extrabold tracking-tight text-gray-900 dark:text-white sm:text-6xl">
             <span className="block lg:inline">Many solutions,</span>
             <span className="block lg:inline"> for different goals</span>
             <a
               aria-hidden="true"
               tabIndex={-1}
               href="#tools-review"
-              className="text-gray-900 dark:text-white flex inline-flex items-center"
+              className="flex inline-flex items-center text-gray-900 dark:text-white"
             >
               <LinkIcon className="ml-2 h-6 w-6 opacity-0 group-hover:opacity-100" />
             </a>
@@ -290,14 +290,14 @@ export function ToolsReview() {
 
       {/* Feature comparison (up to lg) */}
       <section className="lg:hidden">
-        <div className="max-w-2xl mx-auto py-16 px-4 space-y-16 sm:px-6">
+        <div className="mx-auto max-w-2xl space-y-16 py-16 px-4 sm:px-6">
           {tools.map((tool, toolIndex) => (
             <div
               key={tool.title}
               className="border-t border-slate-100 dark:border-slate-900"
             >
-              <div className="-mt-px pt-6 border-t-2 sm:w-1/2">
-                <h3 className="text-gray-700 dark:text-gray-300 text-sm font-bold">
+              <div className="-mt-px border-t-2 pt-6 sm:w-1/2">
+                <h3 className="text-sm font-bold text-gray-700 dark:text-gray-300">
                   {tool.title}{' '}
                   {tool.organization ? (
                     <span className="ml-2 text-xs font-normal">
@@ -313,33 +313,33 @@ export function ToolsReview() {
                 Fast
               </div>
 
-              <div className="mt-6 relative">
+              <div className="relative mt-6">
                 {/* Fake card background */}
                 <div
                   aria-hidden="true"
-                  className="hidden absolute inset-0 pointer-events-none sm:block"
+                  className="pointer-events-none absolute inset-0 hidden sm:block"
                 >
-                  <div className="shadow absolute right-0 w-1/2 h-full bg-slate-100 dark:bg-slate-700 rounded-lg" />
+                  <div className="absolute right-0 h-full w-1/2 rounded-lg bg-slate-100 shadow dark:bg-slate-700" />
                 </div>
 
-                <div className="ring-1 ring-black ring-opacity-5 shadow relative py-3 px-4 bg-slate-100 dark:bg-slate-700 rounded-lg sm:p-0 sm:bg-transparent sm:rounded-none sm:ring-0 sm:shadow-none">
+                <div className="relative rounded-lg bg-slate-100 py-3 px-4 shadow ring-1 ring-black ring-opacity-5 dark:bg-slate-700 sm:rounded-none sm:bg-transparent sm:p-0 sm:shadow-none sm:ring-0">
                   <dl className="divide-y divide-slate-300 dark:divide-slate-600">
                     {fast.map((feature) => (
                       <div
                         key={feature.title}
-                        className="py-3 flex items-center justify-between sm:grid sm:grid-cols-2"
+                        className="flex items-center justify-between py-3 sm:grid sm:grid-cols-2"
                       >
                         <dt className="flex pr-4 text-sm font-medium text-gray-700 dark:text-gray-300">
                           <a
                             href={feature.link}
-                            className="inline-flex mr-1 px-2  text-slate-500"
+                            className="mr-1 inline-flex px-2  text-slate-500"
                           >
                             <span className="sr-only">More info</span>
-                            <QuestionMarkCircleIcon className="w-5 h-5" />
+                            <QuestionMarkCircleIcon className="h-5 w-5" />
                           </a>
                           {feature.title}
                         </dt>
-                        <dd className="flex items-center justify-end sm:px-4 sm:justify-center">
+                        <dd className="flex items-center justify-end sm:justify-center sm:px-4">
                           {valuesDictionary[
                             feature.features[toolIndex].value
                           ]()}
@@ -352,9 +352,9 @@ export function ToolsReview() {
                 {/* Fake card border */}
                 <div
                   aria-hidden="true"
-                  className="hidden absolute inset-0 pointer-events-none sm:block"
+                  className="pointer-events-none absolute inset-0 hidden sm:block"
                 >
-                  <div className="ring-1 ring-black ring-opacity-5 absolute right-0 w-1/2 h-full rounded-lg" />
+                  <div className="absolute right-0 h-full w-1/2 rounded-lg ring-1 ring-black ring-opacity-5" />
                 </div>
               </div>
 
@@ -362,29 +362,29 @@ export function ToolsReview() {
                 Understandable
               </div>
 
-              <div className="mt-6 relative">
+              <div className="relative mt-6">
                 {/* Fake card background */}
                 <div
                   aria-hidden="true"
-                  className="hidden absolute inset-0 pointer-events-none sm:block"
+                  className="pointer-events-none absolute inset-0 hidden sm:block"
                 >
-                  <div className="absolute right-0 w-1/2 h-full bg-slate-100 dark:bg-slate-700 rounded-lg" />
+                  <div className="absolute right-0 h-full w-1/2 rounded-lg bg-slate-100 dark:bg-slate-700" />
                 </div>
 
-                <div className="ring-1 ring-black ring-opacity-5 shadow relative py-3 px-4 bg-slate-100 dark:bg-slate-700 rounded-lg sm:p-0 sm:bg-transparent sm:rounded-none sm:ring-0 sm:shadow-none">
+                <div className="relative rounded-lg bg-slate-100 py-3 px-4 shadow ring-1 ring-black ring-opacity-5 dark:bg-slate-700 sm:rounded-none sm:bg-transparent sm:p-0 sm:shadow-none sm:ring-0">
                   <dl className="divide-y divide-slate-300 dark:divide-slate-600">
                     {understandable.map((feature) => (
                       <div
                         key={feature.title}
-                        className="py-3 flex justify-between sm:grid sm:grid-cols-2"
+                        className="flex justify-between py-3 sm:grid sm:grid-cols-2"
                       >
                         <dt className="flex text-sm font-medium text-gray-700 dark:text-gray-300 sm:pr-4">
                           <a
                             href={feature.link}
-                            className="inline-flex mr-1 px-2 text-slate-500"
+                            className="mr-1 inline-flex px-2 text-slate-500"
                           >
                             <span className="sr-only">More info</span>
-                            <QuestionMarkCircleIcon className="w-5 h-5" />
+                            <QuestionMarkCircleIcon className="h-5 w-5" />
                           </a>
                           {feature.title}
                         </dt>
@@ -401,9 +401,9 @@ export function ToolsReview() {
                 {/* Fake card border */}
                 <div
                   aria-hidden="true"
-                  className="hidden absolute inset-0 pointer-events-none sm:block"
+                  className="pointer-events-none absolute inset-0 hidden sm:block"
                 >
-                  <div className="ring-1 ring-black ring-opacity-5 absolute right-0 w-1/2 h-full rounded-lg" />
+                  <div className="absolute right-0 h-full w-1/2 rounded-lg ring-1 ring-black ring-opacity-5" />
                 </div>
               </div>
 
@@ -411,29 +411,29 @@ export function ToolsReview() {
                 Manageable
               </div>
 
-              <div className="mt-6 relative">
+              <div className="relative mt-6">
                 {/* Fake card background */}
                 <div
                   aria-hidden="true"
-                  className="hidden absolute inset-0 pointer-events-none sm:block"
+                  className="pointer-events-none absolute inset-0 hidden sm:block"
                 >
-                  <div className="shadow absolute right-0 w-1/2 h-full bg-slate-100 dark:bg-slate-700 rounded-lg" />
+                  <div className="absolute right-0 h-full w-1/2 rounded-lg bg-slate-100 shadow dark:bg-slate-700" />
                 </div>
 
-                <div className="ring-1 ring-black ring-opacity-5 shadow relative py-3 px-4 bg-slate-100 dark:bg-slate-700 rounded-lg sm:p-0 sm:bg-transparent sm:rounded-none sm:ring-0 sm:shadow-none">
+                <div className="relative rounded-lg bg-slate-100 py-3 px-4 shadow ring-1 ring-black ring-opacity-5 dark:bg-slate-700 sm:rounded-none sm:bg-transparent sm:p-0 sm:shadow-none sm:ring-0">
                   <dl className="divide-y divide-slate-300 dark:divide-slate-600">
                     {manageable.map((feature) => (
                       <div
                         key={feature.title}
-                        className="py-3 flex justify-between sm:grid sm:grid-cols-2"
+                        className="flex justify-between py-3 sm:grid sm:grid-cols-2"
                       >
                         <dt className="flex text-sm font-medium text-gray-700 dark:text-gray-300 sm:pr-4">
                           <a
                             href={feature.link}
-                            className="inline-flex mr-1 px-2  text-slate-500"
+                            className="mr-1 inline-flex px-2  text-slate-500"
                           >
                             <span className="sr-only">More info</span>
-                            <QuestionMarkCircleIcon className="w-5 h-5" />
+                            <QuestionMarkCircleIcon className="h-5 w-5" />
                           </a>
                           {feature.title}
                         </dt>
@@ -450,9 +450,9 @@ export function ToolsReview() {
                 {/* Fake card border */}
                 <div
                   aria-hidden="true"
-                  className="hidden absolute inset-0 pointer-events-none sm:block"
+                  className="pointer-events-none absolute inset-0 hidden sm:block"
                 >
-                  <div className="ring-1 ring-black ring-opacity-5 absolute right-0 w-1/2 h-full rounded-lg" />
+                  <div className="absolute right-0 h-full w-1/2 rounded-lg ring-1 ring-black ring-opacity-5" />
                 </div>
               </div>
             </div>
@@ -462,20 +462,20 @@ export function ToolsReview() {
 
       {/* Feature comparison (lg+) */}
       <section className="hidden lg:block">
-        <div className="max-w-7xl mx-auto py-24 px-8">
-          <div className="w-full border-t border-slate-100 dark:border-slate-900 flex items-stretch">
-            <div className="-mt-px w-[14.3%] py-6 pr-4 flex items-end" />
+        <div className="mx-auto max-w-7xl py-24 px-8">
+          <div className="flex w-full items-stretch border-t border-slate-100 dark:border-slate-900">
+            <div className="-mt-px flex w-[14.3%] items-end py-6 pr-4" />
             {tools.map((tool, toolIndex) => (
               <div
                 key={tool.title}
                 aria-hidden="true"
                 className={classNames(
                   toolIndex === tools.length - 1 ? '' : 'pr-4',
-                  '-mt-px pl-4 w-[14.3%]'
+                  '-mt-px w-[14.3%] pl-4'
                 )}
               >
-                <div className="border-transparent py-6 border-t-2">
-                  <p className="text-gray-700 dark:text-gray-300 text-md font-bold">
+                <div className="border-t-2 border-transparent py-6">
+                  <p className="text-md font-bold text-gray-700 dark:text-gray-300">
                     {tool.title}{' '}
                     {tool.organization ? (
                       <span className="ml-2 text-xs font-normal">
@@ -491,8 +491,8 @@ export function ToolsReview() {
             ))}
           </div>
 
-          <div className="w-full border-t border-slate-100 dark:border-slate-900 flex items-stretch">
-            <div className="-mt-px w-[14.3%] py-6 pr-4 flex items-end">
+          <div className="flex w-full items-stretch border-t border-slate-100 dark:border-slate-900">
+            <div className="-mt-px flex w-[14.3%] items-end py-6 pr-4">
               <h3 className="mt-auto text-sm font-bold text-gray-700 dark:text-gray-300">
                 Fast
               </h3>
@@ -501,27 +501,27 @@ export function ToolsReview() {
           <div className="relative">
             {/* Fake card backgrounds */}
             <div
-              className="absolute inset-0 flex items-stretch pointer-events-none"
+              className="pointer-events-none absolute inset-0 flex items-stretch"
               aria-hidden="true"
             >
               <div className="w-[14.3%] pr-5" />
               <div className="w-[14.3%] px-5">
-                <div className="w-full h-full bg-slate-100 dark:bg-slate-700 rounded-lg shadow" />
+                <div className="h-full w-full rounded-lg bg-slate-100 shadow dark:bg-slate-700" />
               </div>
               <div className="w-[14.3%] px-5">
-                <div className="w-full h-full bg-slate-100 dark:bg-slate-700 rounded-lg shadow-md" />
+                <div className="h-full w-full rounded-lg bg-slate-100 shadow-md dark:bg-slate-700" />
               </div>
               <div className="w-[14.3%] px-5">
-                <div className="w-full h-full bg-slate-100 dark:bg-slate-700 rounded-lg shadow-md" />
+                <div className="h-full w-full rounded-lg bg-slate-100 shadow-md dark:bg-slate-700" />
               </div>
               <div className="w-[14.3%] pl-5">
-                <div className="w-full h-full bg-slate-100 dark:bg-slate-700 rounded-lg shadow" />
+                <div className="h-full w-full rounded-lg bg-slate-100 shadow dark:bg-slate-700" />
               </div>
               <div className="w-[14.3%] pl-5">
-                <div className="w-full h-full bg-slate-100 dark:bg-slate-700 rounded-lg shadow" />
+                <div className="h-full w-full rounded-lg bg-slate-100 shadow dark:bg-slate-700" />
               </div>
               <div className="w-[14.3%] pl-5">
-                <div className="w-full h-full bg-slate-100 dark:bg-slate-700 rounded-lg shadow" />
+                <div className="h-full w-full rounded-lg bg-slate-100 shadow dark:bg-slate-700" />
               </div>
             </div>
 
@@ -564,7 +564,7 @@ export function ToolsReview() {
                           'relative w-[14.3%] py-0 text-center'
                         )}
                       >
-                        <span className="relative w-full h-full py-3">
+                        <span className="relative h-full w-full py-3">
                           {valuesDictionary[tier.value]()}
                         </span>
                       </td>
@@ -576,27 +576,27 @@ export function ToolsReview() {
 
             {/* Fake card borders */}
             <div
-              className="absolute inset-0 flex items-stretch pointer-events-none"
+              className="pointer-events-none absolute inset-0 flex items-stretch"
               aria-hidden="true"
             >
               <div className="w-[14.3%] pr-5" />
               <div className="w-[14.3%] px-5">
-                <div className="w-full h-full rounded-lg ring-1 ring-black ring-opacity-5" />
+                <div className="h-full w-full rounded-lg ring-1 ring-black ring-opacity-5" />
               </div>
               <div className="w-[14.3%] px-5">
-                <div className="w-full h-full rounded-lg ring-2 ring-black ring-opacity-5" />
+                <div className="h-full w-full rounded-lg ring-2 ring-black ring-opacity-5" />
               </div>
               <div className="w-[14.3%] px-5">
-                <div className="w-full h-full rounded-lg ring-2 ring-black ring-opacity-5" />
+                <div className="h-full w-full rounded-lg ring-2 ring-black ring-opacity-5" />
               </div>
               <div className="w-[14.3%] pl-5">
-                <div className="w-full h-full rounded-lg ring-1 ring-black ring-opacity-5" />
+                <div className="h-full w-full rounded-lg ring-1 ring-black ring-opacity-5" />
               </div>
               <div className="w-[14.3%] pl-5">
-                <div className="w-full h-full rounded-lg ring-1 ring-black ring-opacity-5" />
+                <div className="h-full w-full rounded-lg ring-1 ring-black ring-opacity-5" />
               </div>
               <div className="w-[14.3%] pl-5">
-                <div className="w-full h-full rounded-lg ring-1 ring-black ring-opacity-5" />
+                <div className="h-full w-full rounded-lg ring-1 ring-black ring-opacity-5" />
               </div>
             </div>
           </div>
@@ -604,30 +604,30 @@ export function ToolsReview() {
           <h3 className="mt-10 text-sm font-bold text-gray-700 dark:text-gray-300">
             Understandable
           </h3>
-          <div className="mt-6 relative">
+          <div className="relative mt-6">
             {/* Fake card backgrounds */}
             <div
-              className="absolute inset-0 flex items-stretch pointer-events-none"
+              className="pointer-events-none absolute inset-0 flex items-stretch"
               aria-hidden="true"
             >
               <div className="w-[14.3%] pr-4" />
               <div className="w-[14.3%] px-4">
-                <div className="w-full h-full bg-slate-100 dark:bg-slate-700 rounded-lg shadow" />
+                <div className="h-full w-full rounded-lg bg-slate-100 shadow dark:bg-slate-700" />
               </div>
               <div className="w-[14.3%] px-4">
-                <div className="w-full h-full bg-slate-100 dark:bg-slate-700 rounded-lg shadow-md" />
+                <div className="h-full w-full rounded-lg bg-slate-100 shadow-md dark:bg-slate-700" />
               </div>
               <div className="w-[14.3%] px-4">
-                <div className="w-full h-full bg-slate-100 dark:bg-slate-700 rounded-lg shadow-md" />
+                <div className="h-full w-full rounded-lg bg-slate-100 shadow-md dark:bg-slate-700" />
               </div>
               <div className="w-[14.3%] px-4">
-                <div className="w-full h-full bg-slate-100 dark:bg-slate-700 rounded-lg shadow-md" />
+                <div className="h-full w-full rounded-lg bg-slate-100 shadow-md dark:bg-slate-700" />
               </div>
               <div className="w-[14.3%] px-4">
-                <div className="w-full h-full bg-slate-100 dark:bg-slate-700 rounded-lg shadow-md" />
+                <div className="h-full w-full rounded-lg bg-slate-100 shadow-md dark:bg-slate-700" />
               </div>
               <div className="w-[14.3%] pl-4">
-                <div className="w-full h-full bg-slate-100 dark:bg-slate-700 rounded-lg shadow" />
+                <div className="h-full w-full rounded-lg bg-slate-100 shadow dark:bg-slate-700" />
               </div>
             </div>
 
@@ -690,27 +690,27 @@ export function ToolsReview() {
 
             {/* Fake card borders */}
             <div
-              className="absolute inset-0 flex items-stretch pointer-events-none"
+              className="pointer-events-none absolute inset-0 flex items-stretch"
               aria-hidden="true"
             >
               <div className="w-[14.3%] pr-4" />
               <div className="w-[14.3%] px-4">
-                <div className="w-full h-full rounded-lg ring-1 ring-black ring-opacity-5" />
+                <div className="h-full w-full rounded-lg ring-1 ring-black ring-opacity-5" />
               </div>
               <div className="w-[14.3%] px-4">
-                <div className="w-full h-full rounded-lg ring-2 ring-black ring-opacity-5" />
+                <div className="h-full w-full rounded-lg ring-2 ring-black ring-opacity-5" />
               </div>
               <div className="w-[14.3%] px-4">
-                <div className="w-full h-full rounded-lg ring-2 ring-black ring-opacity-5" />
+                <div className="h-full w-full rounded-lg ring-2 ring-black ring-opacity-5" />
               </div>
               <div className="w-[14.3%] px-4">
-                <div className="w-full h-full rounded-lg ring-2 ring-black ring-opacity-5" />
+                <div className="h-full w-full rounded-lg ring-2 ring-black ring-opacity-5" />
               </div>
               <div className="w-[14.3%] px-4">
-                <div className="w-full h-full rounded-lg ring-2 ring-black ring-opacity-5" />
+                <div className="h-full w-full rounded-lg ring-2 ring-black ring-opacity-5" />
               </div>
               <div className="w-[14.3%] pl-4">
-                <div className="w-full h-full rounded-lg ring-1 ring-black ring-opacity-5" />
+                <div className="h-full w-full rounded-lg ring-1 ring-black ring-opacity-5" />
               </div>
             </div>
           </div>
@@ -718,30 +718,30 @@ export function ToolsReview() {
           <h3 className="mt-10 text-sm font-bold text-gray-700 dark:text-gray-300">
             Manageable
           </h3>
-          <div className="mt-6 relative">
+          <div className="relative mt-6">
             {/* Fake card backgrounds */}
             <div
-              className="absolute inset-0 flex items-stretch pointer-events-none"
+              className="pointer-events-none absolute inset-0 flex items-stretch"
               aria-hidden="true"
             >
               <div className="w-[14.3%] pr-4" />
               <div className="w-[14.3%] px-4">
-                <div className="w-full h-full bg-slate-100 dark:bg-slate-700 rounded-lg shadow" />
+                <div className="h-full w-full rounded-lg bg-slate-100 shadow dark:bg-slate-700" />
               </div>
               <div className="w-[14.3%] px-4">
-                <div className="w-full h-full bg-slate-100 dark:bg-slate-700 rounded-lg shadow-md" />
+                <div className="h-full w-full rounded-lg bg-slate-100 shadow-md dark:bg-slate-700" />
               </div>
               <div className="w-[14.3%] px-4">
-                <div className="w-full h-full bg-slate-100 dark:bg-slate-700 rounded-lg shadow-md" />
+                <div className="h-full w-full rounded-lg bg-slate-100 shadow-md dark:bg-slate-700" />
               </div>
               <div className="w-[14.3%] px-4">
-                <div className="w-full h-full bg-slate-100 dark:bg-slate-700 rounded-lg shadow-md" />
+                <div className="h-full w-full rounded-lg bg-slate-100 shadow-md dark:bg-slate-700" />
               </div>
               <div className="w-[14.3%] px-4">
-                <div className="w-full h-full bg-slate-100 dark:bg-slate-700 rounded-lg shadow-md" />
+                <div className="h-full w-full rounded-lg bg-slate-100 shadow-md dark:bg-slate-700" />
               </div>
               <div className="w-[14.3%] pl-4">
-                <div className="w-full h-full bg-slate-100 dark:bg-slate-700 rounded-lg shadow" />
+                <div className="h-full w-full rounded-lg bg-slate-100 shadow dark:bg-slate-700" />
               </div>
             </div>
 
@@ -794,58 +794,58 @@ export function ToolsReview() {
 
             {/* Fake card borders */}
             <div
-              className="absolute inset-0 flex items-stretch pointer-events-none"
+              className="pointer-events-none absolute inset-0 flex items-stretch"
               aria-hidden="true"
             >
               <div className="w-[14.3%] pr-4" />
               <div className="w-[14.3%] px-4">
-                <div className="w-full h-full rounded-lg ring-1 ring-black ring-opacity-5" />
+                <div className="h-full w-full rounded-lg ring-1 ring-black ring-opacity-5" />
               </div>
               <div className="w-[14.3%] px-4">
-                <div className="w-full h-full rounded-lg ring-2 ring-black ring-opacity-5" />
+                <div className="h-full w-full rounded-lg ring-2 ring-black ring-opacity-5" />
               </div>
               <div className="w-[14.3%] px-4">
-                <div className="w-full h-full rounded-lg ring-2 ring-black ring-opacity-5" />
+                <div className="h-full w-full rounded-lg ring-2 ring-black ring-opacity-5" />
               </div>
               <div className="w-[14.3%] px-4">
-                <div className="w-full h-full rounded-lg ring-2 ring-black ring-opacity-5" />
+                <div className="h-full w-full rounded-lg ring-2 ring-black ring-opacity-5" />
               </div>
               <div className="w-[14.3%] px-4">
-                <div className="w-full h-full rounded-lg ring-2 ring-black ring-opacity-5" />
+                <div className="h-full w-full rounded-lg ring-2 ring-black ring-opacity-5" />
               </div>
               <div className="w-[14.3%] pl-4">
-                <div className="w-full h-full rounded-lg ring-1 ring-black ring-opacity-5" />
+                <div className="h-full w-full rounded-lg ring-1 ring-black ring-opacity-5" />
               </div>
             </div>
           </div>
         </div>
 
-        <div className="flex mt-2 mb-12 max-w-7xl mx-auto px-8 justify-end text-xs">
-          <div className="space-x-3 flex items-center">
+        <div className="mx-auto mt-2 mb-12 flex max-w-7xl justify-end px-8 text-xs">
+          <div className="flex items-center space-x-3">
             <div className="flex items-center">
               <span
                 title="natively supported"
-                className="inline-flex items-center px-2.5 py-0.5 rounded-full text-green-600"
+                className="inline-flex items-center rounded-full px-2.5 py-0.5 text-green-600"
               >
-                <CheckCircleIcon className="w-4 h-4" />
+                <CheckCircleIcon className="h-4 w-4" />
               </span>
               Natively supported
             </div>
             <div className="flex items-center">
               <span
                 title="natively supported"
-                className="inline-flex items-center px-2.5 py-0.5 rounded-full text-slate-400"
+                className="inline-flex items-center rounded-full px-2.5 py-0.5 text-slate-400"
               >
-                <MinusIcon className="w-4 h-4" />
+                <MinusIcon className="h-4 w-4" />
               </span>
               Not supported
             </div>
             <div className="flex items-center">
               <span
                 title="natively supported"
-                className="inline-flex items-center px-2.5 py-0.5 rounded-full text-yellow-600"
+                className="inline-flex items-center rounded-full px-2.5 py-0.5 text-yellow-600"
               >
-                <ExclamationCircleIcon className="w-4 h-4" />
+                <ExclamationCircleIcon className="h-4 w-4" />
               </span>
               Implement your own
             </div>

--- a/libs/website/ui-home/src/lib/tools-support-callout.tsx
+++ b/libs/website/ui-home/src/lib/tools-support-callout.tsx
@@ -1,9 +1,9 @@
 export function ToolsSupportCallout() {
   return (
     <article className="bg-slate-50 dark:bg-slate-800">
-      <div className="max-w-7xl mx-auto py-16 px-4 sm:px-6 lg:px-8">
-        <div className="bg-slate-100 dark:bg-slate-900 rounded-lg shadow-xl overflow-hidden">
-          <div className="pt-10 pb-12 px-6 sm:pt-16 sm:px-16 lg:py-16 lg:pr-0 xl:py-20 xl:px-20">
+      <div className="mx-auto max-w-7xl py-16 px-4 sm:px-6 lg:px-8">
+        <div className="overflow-hidden rounded-lg bg-slate-100 shadow-xl dark:bg-slate-900">
+          <div className="px-6 pt-10 pb-12 sm:px-16 sm:pt-16 lg:py-16 lg:pr-0 xl:py-20 xl:px-20">
             <h1 className="text-3xl font-extrabold text-gray-900 dark:text-white sm:text-4xl">
               <span className="block text-gray-900 dark:text-white">
                 It's not just about the features.

--- a/libs/website/ui-home/src/lib/what-is-a-monorepo.tsx
+++ b/libs/website/ui-home/src/lib/what-is-a-monorepo.tsx
@@ -4,36 +4,36 @@ export function WhatIsAMonorepo() {
   return (
     <div
       id="what-is-a-monorepo"
-      className="py-16 bg-slate-50 dark:bg-slate-800 overflow-hidden lg:py-24"
+      className="overflow-hidden bg-slate-50 py-16 dark:bg-slate-800 lg:py-24"
     >
-      <div className="relative mx-auto px-4 sm:px-6 lg:px-8 lg:max-w-7xl">
+      <div className="relative mx-auto px-4 sm:px-6 lg:max-w-7xl lg:px-8">
         <header className="relative">
-          <div className="text-center text-4xl font-extrabold tracking-tight text-gray-900 dark:text-white sm:text-5xl group">
+          <div className="group text-center text-4xl font-extrabold tracking-tight text-gray-900 dark:text-white sm:text-5xl">
             # What is a Monorepo?
             <a
               aria-hidden="true"
               tabIndex={-1}
               href="#what-is-a-monorepo"
-              className="text-gray-900 dark:text-white flex inline-flex items-center"
+              className="flex inline-flex items-center text-gray-900 dark:text-white"
             >
               <LinkIcon className="ml-2 h-6 w-6 opacity-0 group-hover:opacity-100" />
             </a>
           </div>
-          <p className="mt-4 max-w-3xl mx-auto text-center text-xl text-gray-700 dark:text-gray-300">
+          <p className="mx-auto mt-4 max-w-3xl text-center text-xl text-gray-700 dark:text-gray-300">
             Let's define what we and others typically mean when we talk about
             Monorepos.
           </p>
         </header>
 
-        <article className="relative mt-12 lg:mt-24 lg:grid lg:grid-cols-2 lg:gap-8 lg:items-center">
+        <article className="relative mt-12 lg:mt-24 lg:grid lg:grid-cols-2 lg:items-center lg:gap-8">
           <div className="relative">
-            <h2 className="text-2xl leading-loose font-bold text-gray-800 dark:text-gray-100 tracking-tight sm:text-3xl sm:leading-relaxed">
+            <h2 className="text-2xl font-bold leading-loose tracking-tight text-gray-800 dark:text-gray-100 sm:text-3xl sm:leading-relaxed">
               A monorepo is a single repository containing{' '}
-              <mark className="px-1 bg-yellow-500 rounded-md">
+              <mark className="rounded-md bg-yellow-500 px-1">
                 multiple distinct projects
               </mark>
               , with{' '}
-              <mark className="px-1 bg-yellow-500 rounded-md">
+              <mark className="rounded-md bg-yellow-500 px-1">
                 well-defined relationships
               </mark>
               .
@@ -45,7 +45,7 @@ export function WhatIsAMonorepo() {
             </p>
           </div>
 
-          <div className="mt-10 -mx-4 relative lg:mt-0" aria-hidden="true">
+          <div className="relative -mx-4 mt-10 lg:mt-0" aria-hidden="true">
             <img
               aria-hidden="true"
               loading="lazy"
@@ -58,9 +58,9 @@ export function WhatIsAMonorepo() {
         </article>
 
         <article className="relative mt-12 sm:mt-16 lg:mt-24">
-          <div className="lg:grid lg:grid-flow-row-dense lg:grid-cols-2 lg:gap-8 lg:items-center">
+          <div className="lg:grid lg:grid-flow-row-dense lg:grid-cols-2 lg:items-center lg:gap-8">
             <div className="lg:col-start-2">
-              <h2 className="text-2xl leading-loose font-bold text-gray-800 dark:text-gray-100 tracking-tight sm:text-3xl sm:leading-relaxed">
+              <h2 className="text-2xl font-bold leading-loose tracking-tight text-gray-800 dark:text-gray-100 sm:text-3xl sm:leading-relaxed">
                 Not just &ldquo;code colocation&rdquo;
               </h2>
               <p className="mt-3 text-lg text-gray-700 dark:text-gray-300">
@@ -82,7 +82,7 @@ export function WhatIsAMonorepo() {
               </p>
             </div>
 
-            <div className="mt-10 -mx-4 relative lg:mt-0 lg:col-start-1">
+            <div className="relative -mx-4 mt-10 lg:col-start-1 lg:mt-0">
               <img
                 aria-hidden="true"
                 loading="lazy"

--- a/libs/website/ui-home/src/lib/why-a-monorepo.tsx
+++ b/libs/website/ui-home/src/lib/why-a-monorepo.tsx
@@ -4,36 +4,36 @@ export function WhyAMonorepo() {
   return (
     <div
       id="why-a-monorepo"
-      className="bg-slate-50 dark:bg-slate-800 pt-16 pb-20 px-4 sm:px-6 lg:pt-24 lg:pb-28 lg:px-8"
+      className="bg-slate-50 px-4 pt-16 pb-20 dark:bg-slate-800 sm:px-6 lg:px-8 lg:pt-24 lg:pb-28"
     >
       <div className="relative">
-        <div className="text-center text-4xl leading-8 font-extrabold tracking-tight text-gray-900 dark:text-white sm:text-5xl group">
+        <div className="group text-center text-4xl font-extrabold leading-8 tracking-tight text-gray-900 dark:text-white sm:text-5xl">
           # But why?
           <a
             aria-hidden="true"
             tabIndex={-1}
             href="#why-a-monorepo"
-            className="text-gray-900 dark:text-white flex inline-flex items-center"
+            className="flex inline-flex items-center text-gray-900 dark:text-white"
           >
             <LinkIcon className="ml-2 h-6 w-6 opacity-0 group-hover:opacity-100" />
           </a>
         </div>
-        <p className="mt-4 max-w-3xl mx-auto text-center text-xl text-gray-700 dark:text-gray-300">
+        <p className="mx-auto mt-4 max-w-3xl text-center text-xl text-gray-700 dark:text-gray-300">
           Let's go deeper into the rabbit hole.
         </p>
       </div>
-      <article className="mt-24 lg:mt-36 relative max-w-lg mx-auto lg:max-w-7xl">
-        <div className="max-w-2xl mx-auto">
+      <article className="relative mx-auto mt-24 max-w-lg lg:mt-36 lg:max-w-7xl">
+        <div className="mx-auto max-w-2xl">
           <h1
             id="polyrepo-concept"
-            className="text-3xl tracking-tight font-semibold text-gray-800 dark:text-gray-100 sm:text-4xl group"
+            className="group text-3xl font-semibold tracking-tight text-gray-800 dark:text-gray-100 sm:text-4xl"
           >
             A &ldquo;Polyrepo&rdquo;
             <a
               aria-hidden="true"
               tabIndex={-1}
               href="#polyrepo-concept"
-              className="text-gray-900 dark:text-white flex inline-flex items-center"
+              className="flex inline-flex items-center text-gray-900 dark:text-white"
             >
               <LinkIcon className="ml-2 h-6 w-6 opacity-0 group-hover:opacity-100" />
             </a>
@@ -48,7 +48,7 @@ export function WhyAMonorepo() {
           <img
             aria-hidden="true"
             loading="lazy"
-            className="mt-10 w-full h-full object-cover"
+            className="mt-10 h-full w-full object-cover"
             src="/images/polyrepo-practice.svg"
             alt="polyrepo practice"
           />
@@ -62,7 +62,7 @@ export function WhyAMonorepo() {
           <img
             aria-hidden="true"
             loading="lazy"
-            className="mt-10 w-full h-full object-cover"
+            className="mt-10 h-full w-full object-cover"
             src="/images/spectrum-real-world.svg"
             alt="spectrum real world"
           />
@@ -73,15 +73,15 @@ export function WhyAMonorepo() {
             drawbacks to a polyrepo environment:
           </p>
         </div>
-        <div className="mt-12 grid gap-16 pt-12 lg:grid-cols-2 lg:gap-22">
+        <div className="lg:gap-22 mt-12 grid gap-16 pt-12 lg:grid-cols-2">
           {/*item*/}
-          <section className="px-4 py-6 bg-slate-100 dark:bg-slate-900 rounded-md shadow-md">
+          <section className="rounded-md bg-slate-100 px-4 py-6 shadow-md dark:bg-slate-900">
             <div>
-              <span className="inline-flex items-center px-3 py-0.5 rounded-full text-xs font-medium bg-slate-200 dark:bg-slate-700 text-gray-700 dark:text-gray-300 capitalize">
+              <span className="inline-flex items-center rounded-full bg-slate-200 px-3 py-0.5 text-xs font-medium capitalize text-gray-700 dark:bg-slate-700 dark:text-gray-300">
                 Polyrepo
               </span>
             </div>
-            <div className="block mt-4">
+            <div className="mt-4 block">
               <h2 className="text-xl font-semibold text-gray-700 dark:text-gray-300">
                 Cumbersome code sharing
               </h2>
@@ -95,13 +95,13 @@ export function WhyAMonorepo() {
               </p>
             </div>
           </section>
-          <section className="px-4 py-6 bg-slate-100 dark:bg-slate-900 rounded-md shadow-md">
+          <section className="rounded-md bg-slate-100 px-4 py-6 shadow-md dark:bg-slate-900">
             <div>
-              <span className="inline-flex items-center px-3 py-0.5 rounded-full text-xs font-medium bg-slate-200 dark:bg-slate-700 text-gray-700 dark:text-gray-300 capitalize">
+              <span className="inline-flex items-center rounded-full bg-slate-200 px-3 py-0.5 text-xs font-medium capitalize text-gray-700 dark:bg-slate-700 dark:text-gray-300">
                 Polyrepo
               </span>
             </div>
-            <div className="block mt-4">
+            <div className="mt-4 block">
               <h2 className="text-xl font-semibold text-gray-700 dark:text-gray-300">
                 Significant code duplication
               </h2>
@@ -114,13 +114,13 @@ export function WhyAMonorepo() {
               </p>
             </div>
           </section>
-          <section className="px-4 py-6 bg-slate-100 dark:bg-slate-900 rounded-md shadow-md">
+          <section className="rounded-md bg-slate-100 px-4 py-6 shadow-md dark:bg-slate-900">
             <div>
-              <span className="inline-flex items-center px-3 py-0.5 rounded-full text-xs font-medium bg-slate-200 dark:bg-slate-700 text-gray-700 dark:text-gray-300 capitalize">
+              <span className="inline-flex items-center rounded-full bg-slate-200 px-3 py-0.5 text-xs font-medium capitalize text-gray-700 dark:bg-slate-700 dark:text-gray-300">
                 Polyrepo
               </span>
             </div>
-            <div className="block mt-4">
+            <div className="mt-4 block">
               <h2 className="text-xl font-semibold text-gray-700 dark:text-gray-300">
                 Costly cross-repo changes to shared libraries and consumers
               </h2>
@@ -133,13 +133,13 @@ export function WhyAMonorepo() {
               </p>
             </div>
           </section>
-          <section className="px-4 py-6 bg-slate-100 dark:bg-slate-900 rounded-md shadow-md">
+          <section className="rounded-md bg-slate-100 px-4 py-6 shadow-md dark:bg-slate-900">
             <div>
-              <span className="inline-flex items-center px-3 py-0.5 rounded-full text-xs font-medium bg-slate-200 dark:bg-slate-700 text-gray-700 dark:text-gray-300 capitalize">
+              <span className="inline-flex items-center rounded-full bg-slate-200 px-3 py-0.5 text-xs font-medium capitalize text-gray-700 dark:bg-slate-700 dark:text-gray-300">
                 Polyrepo
               </span>
             </div>
-            <div className="block mt-4">
+            <div className="mt-4 block">
               <h2 className="text-xl font-semibold text-gray-700 dark:text-gray-300">
                 Inconsistent tooling
               </h2>
@@ -153,18 +153,18 @@ export function WhyAMonorepo() {
           </section>
         </div>
       </article>
-      <article className="mt-24 lg:mt-36 relative max-w-lg mx-auto lg:max-w-7xl">
-        <div className="max-w-2xl mx-auto">
+      <article className="relative mx-auto mt-24 max-w-lg lg:mt-36 lg:max-w-7xl">
+        <div className="mx-auto max-w-2xl">
           <h1
             id="monorepo-concept"
-            className="text-3xl tracking-tight font-semibold text-gray-800 dark:text-gray-100 sm:text-4xl group"
+            className="group text-3xl font-semibold tracking-tight text-gray-800 dark:text-gray-100 sm:text-4xl"
           >
             A &ldquo;Monorepo&rdquo;
             <a
               aria-hidden="true"
               tabIndex={-1}
               href="#monorepo-concept"
-              className="text-gray-900 dark:text-white flex inline-flex items-center"
+              className="flex inline-flex items-center text-gray-900 dark:text-white"
             >
               <LinkIcon className="ml-2 h-6 w-6 opacity-0 group-hover:opacity-100" />
             </a>
@@ -175,15 +175,15 @@ export function WhyAMonorepo() {
           </p>
         </div>
 
-        <div className="mt-12 grid gap-16 pt-12 lg:grid-cols-2 lg:gap-22">
+        <div className="lg:gap-22 mt-12 grid gap-16 pt-12 lg:grid-cols-2">
           {/*item*/}
-          <section className="px-4 py-6 bg-slate-100 dark:bg-slate-900 rounded-md shadow-md">
+          <section className="rounded-md bg-slate-100 px-4 py-6 shadow-md dark:bg-slate-900">
             <div>
-              <span className="inline-flex items-center px-3 py-0.5 rounded-full text-xs font-medium bg-slate-200 dark:bg-slate-700 text-gray-700 dark:text-gray-300 capitalize">
+              <span className="inline-flex items-center rounded-full bg-slate-200 px-3 py-0.5 text-xs font-medium capitalize text-gray-700 dark:bg-slate-700 dark:text-gray-300">
                 Monorepo
               </span>
             </div>
-            <div className="block mt-4">
+            <div className="mt-4 block">
               <h2 className="text-xl font-semibold text-gray-700 dark:text-gray-300">
                 No overhead to create new projects
               </h2>
@@ -193,13 +193,13 @@ export function WhyAMonorepo() {
               </p>
             </div>
           </section>
-          <section className="px-4 py-6 bg-slate-100 dark:bg-slate-900 rounded-md shadow-md">
+          <section className="rounded-md bg-slate-100 px-4 py-6 shadow-md dark:bg-slate-900">
             <div>
-              <span className="inline-flex items-center px-3 py-0.5 rounded-full text-xs font-medium bg-slate-200 dark:bg-slate-700 text-gray-700 dark:text-gray-300 capitalize">
+              <span className="inline-flex items-center rounded-full bg-slate-200 px-3 py-0.5 text-xs font-medium capitalize text-gray-700 dark:bg-slate-700 dark:text-gray-300">
                 Monorepo
               </span>
             </div>
-            <div className="block mt-4">
+            <div className="mt-4 block">
               <h2 className="text-xl font-semibold text-gray-700 dark:text-gray-300">
                 Atomic commits across projects
               </h2>
@@ -209,13 +209,13 @@ export function WhyAMonorepo() {
               </p>
             </div>
           </section>
-          <section className="px-4 py-6 bg-slate-100 dark:bg-slate-900 rounded-md shadow-md">
+          <section className="rounded-md bg-slate-100 px-4 py-6 shadow-md dark:bg-slate-900">
             <div>
-              <span className="inline-flex items-center px-3 py-0.5 rounded-full text-xs font-medium bg-slate-200 dark:bg-slate-700 text-gray-700 dark:text-gray-300 capitalize">
+              <span className="inline-flex items-center rounded-full bg-slate-200 px-3 py-0.5 text-xs font-medium capitalize text-gray-700 dark:bg-slate-700 dark:text-gray-300">
                 Monorepo
               </span>
             </div>
-            <div className="block mt-4">
+            <div className="mt-4 block">
               <h2 className="text-xl font-semibold text-gray-700 dark:text-gray-300">
                 One version of everything
               </h2>
@@ -225,13 +225,13 @@ export function WhyAMonorepo() {
               </p>
             </div>
           </section>
-          <section className="px-4 py-6 bg-slate-100 dark:bg-slate-900 rounded-md shadow-md">
+          <section className="rounded-md bg-slate-100 px-4 py-6 shadow-md dark:bg-slate-900">
             <div>
-              <span className="inline-flex items-center px-3 py-0.5 rounded-full text-xs font-medium bg-slate-200 dark:bg-slate-700 text-gray-700 dark:text-gray-300 capitalize">
+              <span className="inline-flex items-center rounded-full bg-slate-200 px-3 py-0.5 text-xs font-medium capitalize text-gray-700 dark:bg-slate-700 dark:text-gray-300">
                 Monorepo
               </span>
             </div>
-            <div className="block mt-4">
+            <div className="mt-4 block">
               <h2 className="text-xl font-semibold text-gray-700 dark:text-gray-300">
                 Developer mobility
               </h2>

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "jest": "27.2.3",
     "postcss": "^8.2.13",
     "prettier": "2.5.1",
+    "prettier-plugin-tailwindcss": "^0.1.5",
     "react-test-renderer": "17.0.2",
     "tailwindcss": "^3.0.2",
     "ts-jest": "27.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10108,6 +10108,11 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
+prettier-plugin-tailwindcss@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.1.5.tgz#1709b4cea44873cbfefe9862f9f0827a51fe8cc3"
+  integrity sha512-e+jTxwiHL4I3Ot8OjV1LAiiaAx0Zgy71xTL7xNmJtNmhpja7GKzFSAoulqBDS1D57B7lbZDCvDEKIWIQSBUmBQ==
+
 prettier@2.5.1:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.1.tgz#fff75fa9d519c54cf0fce328c1017d94546bc56a"


### PR DESCRIPTION
Add the `prettier-plugin-tailwindcss` dev dependency to allow automatic format of Tailwindcss classes.