### PR TITLE
Add Earthly to Monorepo Tools

### DIFF
--- a/libs/website/ui-home/src/lib/introduction.tsx
+++ b/libs/website/ui-home/src/lib/introduction.tsx
@@ -79,6 +79,15 @@ export function Introduction() {
                 </a>
                 , &nbsp;
                 <a
+                  href="https://earthly.dev/?utm_source=monorepo.tools"
+                  rel="noreferrer"
+                  target="_blank"
+                  className="border-b border-yellow-500 transition hover:rounded hover:bg-yellow-500 hover:text-gray-800"
+                >
+                  Earthly (by Earthly Technologies)
+                </a>
+                , &nbsp;
+                <a
                   href="https://gradle.org/?utm_source=monorepo.tools"
                   rel="noreferrer"
                   target="_blank"

--- a/libs/website/ui-home/src/lib/monorepo-features.tsx
+++ b/libs/website/ui-home/src/lib/monorepo-features.tsx
@@ -132,6 +132,16 @@ export function MonorepoFeatures() {
             <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
                 <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
+                  <Supported /> Earthly
+                </p>
+              </dt>
+              <dd className="mt-4 text-gray-600 dark:text-gray-400">
+                Earthly supports it.
+              </dd>
+            </div>
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
+              <dt>
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported /> Gradle Build Tool
                 </p>
               </dt>
@@ -247,6 +257,16 @@ export function MonorepoFeatures() {
               </dt>
               <dd className="mt-4 text-gray-600 dark:text-gray-400">
                 Bazel supports it.
+              </dd>
+            </div>
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
+              <dt>
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
+                  <Supported /> Earthly
+                </p>
+              </dt>
+              <dd className="mt-4 text-gray-600 dark:text-gray-400">
+                Earthly supports it.
               </dd>
             </div>
             <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
@@ -370,6 +390,16 @@ export function MonorepoFeatures() {
             <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
                 <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
+                  <NotSupported /> Earthly
+                </p>
+              </dt>
+              <dd className="mt-4 text-gray-600 dark:text-gray-400">
+                Coming soon!
+              </dd>
+            </div>
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
+              <dt>
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported /> Gradle Build Tool
                 </p>
               </dt>
@@ -486,6 +516,16 @@ export function MonorepoFeatures() {
             <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
                 <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
+                  <NotSupported /> Earthly
+                </p>
+              </dt>
+              <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
+                Coming soon!
+              </dd>
+            </div>
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
+              <dt>
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <ManualImplementation /> Gradle Build Tool
                 </p>
               </dt>
@@ -584,6 +624,20 @@ export function MonorepoFeatures() {
               </dt>
               <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
                 This is Bazel's biggest differentiator.
+              </dd>
+            </div>
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
+              <dt>
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
+                  <Supported /> Earthly
+                </p>
+              </dt>
+              <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
+                Earthly's Buildkit backend&nbsp; 
+                <a href="https://docs.earthly.dev/ci-integration/remote-buildkit">
+                  can be hosted remotely
+                </a>
+                &nbsp;and used locally or in CI builds.
               </dd>
             </div>
             <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
@@ -696,6 +750,17 @@ export function MonorepoFeatures() {
               <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
                 Bazel doesn't support it, but it provides the required metadata
                 making it possible to write such functionality yourself.
+              </dd>
+            </div>
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
+              <dt>
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
+                  <Supported /> Earthly
+                </p>
+              </dt>
+              <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
+                Earthly only rebuilds targets which are affected by a change 
+                to their inputs.
               </dd>
             </div>
             <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
@@ -824,6 +889,16 @@ export function MonorepoFeatures() {
             <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
                 <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
+                  <ManualImplementation /> Earthly
+                </p>
+              </dt>
+              <dd className="mt-4 text-gray-600 dark:text-gray-400">
+                Earthly allows you to script and use analysis tools of your choice within sandboxed containers.
+              </dd>
+            </div>
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
+              <dt>
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported /> Gradle Build Tool
                 </p>
               </dt>
@@ -941,6 +1016,16 @@ export function MonorepoFeatures() {
               <dd className="mt-4 text-gray-600 dark:text-gray-400">
                 Bazel's implementation supports a custom query language to
                 filter out node you are not interested in.
+              </dd>
+            </div>
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
+              <dt>
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
+                  <ManualImplementation /> Earthly
+                </p>
+              </dt>
+              <dd className="mt-4 text-gray-600 dark:text-gray-400">
+                Earthly doesn't come with a visualizer but it's possible to write your own or use an existing third-party tool.
               </dd>
             </div>
             <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
@@ -1065,6 +1150,19 @@ export function MonorepoFeatures() {
                 Bazel supports it. Any folder of files can be marked as a
                 project and can be shared. Bazel build rules are used to enable
                 sharing without hurting dev ergonomics.
+              </dd>
+            </div>
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
+              <dt>
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
+                  <Supported />
+                  Earthly
+                </p>
+              </dt>
+              <dd className="mt-4 text-gray-600 dark:text-gray-400">
+                Earthly allows you to share and reference build Targets, 
+                Artifacts, and even User-Defined Commands from multiple 
+                repositories.
               </dd>
             </div>
             <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
@@ -1207,6 +1305,17 @@ export function MonorepoFeatures() {
             <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
               <dt>
                 <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
+                  <Supported />
+                  Earthly
+                </p>
+              </dt>
+              <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
+                Earthly is language agnositic and gives you the freedom to build inside any container with the tooling of your choice.
+              </dd>
+            </div>
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
+              <dt>
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <Supported /> Gradle Build Tool
                 </p>
               </dt>
@@ -1321,6 +1430,17 @@ export function MonorepoFeatures() {
                 <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
                   <ManualImplementation />
                   Bazel
+                </p>
+              </dt>
+              <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
+                External generators can be used.
+              </dd>
+            </div>
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
+              <dt>
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
+                  <ManualImplementation />
+                  Earthly
                 </p>
               </dt>
               <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
@@ -1454,6 +1574,18 @@ export function MonorepoFeatures() {
               <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
                 Bazel supports visibility rules which help you separate what is
                 private from what is public, what can be shared, etc.
+              </dd>
+            </div>
+            <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">
+              <dt>
+                <p className="inline-flex items-center justify-center rounded-md bg-slate-50 px-3 py-2 text-sm uppercase tracking-widest text-gray-700 dark:bg-slate-800 dark:text-gray-300">
+                  <ManualImplementation />
+                  Earthly
+                </p>
+              </dt>
+              <dd className="mt-4 text-base text-gray-600 dark:text-gray-400">
+                A linter with a set of custom rules and extra configuration can
+                be used to ensure that some constraints hold.
               </dd>
             </div>
             <div className="rounded-md border border-slate-200 bg-slate-100 p-4 dark:border-black dark:bg-slate-900">

--- a/libs/website/ui-home/src/lib/monorepo-tools-logos.tsx
+++ b/libs/website/ui-home/src/lib/monorepo-tools-logos.tsx
@@ -5,6 +5,10 @@ const tools: { name: string; link: string }[] = [
     link: 'https://github.com/bazelbuild/bazel?utm_source=monorepo.tools',
   },
   {
+    name: 'Earthly',
+    link: 'https://github.com/earthly/earthly?utm_source=monorepo.tools',
+  },
+  {
     name: 'Gradle',
     link: 'https://github.com/gradle/gradle?utm_source=monorepo.tools',
   },
@@ -32,7 +36,7 @@ const tools: { name: string; link: string }[] = [
 
 export function MonorepoToolsLogos() {
   return (
-    <div className="mt-8 grid grid-cols-1 gap-0.5 py-12 text-2xl font-semibold md:grid-cols-7 lg:mt-16 lg:py-16">
+    <div className="mt-8 grid grid-cols-1 gap-0.5 py-12 text-2xl font-semibold md:grid-cols-8 lg:mt-16 lg:py-16">
       {tools.map((tool) => (
         <a
           key={'tool-' + tool.name}

--- a/libs/website/ui-home/src/lib/resources.tsx
+++ b/libs/website/ui-home/src/lib/resources.tsx
@@ -50,6 +50,13 @@ const people: {
     twitterLink: 'https://twitter.com/JustinReock',
     githubLink: 'https://github.com/gradle/gradle?utm_source=monorepo.tools',
   },
+  {
+    name: 'Brandon Schurman',
+    tool: 'Earthly',
+    imageUrl: 'https://avatars.githubusercontent.com/u/3247216?s=150',
+    twitterLink: 'https://twitter.com/BrSchurman',
+    githubLink: 'https://github.com/earthly/earthly?utm_source=monorepo.tools',
+  },
 ];
 const videosPodcasts: { name: string; link: string }[] = [
   {

--- a/libs/website/ui-home/src/lib/tools-review.tsx
+++ b/libs/website/ui-home/src/lib/tools-review.tsx
@@ -26,6 +26,12 @@ const tools = [
       'A fast, scalable, multi-language and extensible build system.',
   },
   {
+    title: 'Earthly',
+    organization: 'Earthly Technologies',
+    organizationUrl: 'https://earthly.dev/?utm_source=monorepo.tools',
+    description: 'The effortless CI/CD framework that runs anywhere.',
+  },
+  {
     title: 'Gradle',
     organization: 'Gradle, Inc',
     organizationUrl: 'https://gradle.org/?utm_source=monorepo.tools',
@@ -73,6 +79,7 @@ const fast: Item[] = [
       'The ability to store and replay file and process output of tasks.',
     features: [
       { title: 'Bazel', value: 'supported' },
+      { title: 'Earthly', value: 'supported' },
       { title: 'Gradle', value: 'supported' },
       { title: 'Lage', value: 'supported' },
       { title: 'Lerna', value: 'notSupported' },
@@ -87,6 +94,7 @@ const fast: Item[] = [
     tooltip: 'The ability to run tasks in the correct order and in parallel.',
     features: [
       { title: 'Bazel', value: 'supported' },
+      { title: 'Earthly', value: 'supported' },
       { title: 'Gradle', value: 'supported' },
       { title: 'Lage', value: 'supported' },
       { title: 'Lerna', value: 'supported' },
@@ -102,6 +110,7 @@ const fast: Item[] = [
       'The ability to share cache artifacts across different environments.',
     features: [
       { title: 'Bazel', value: 'supported' },
+      { title: 'Earthly', value: 'notSupported' },
       { title: 'Gradle', value: 'supported' },
       { title: 'Lage', value: 'supported' },
       { title: 'Lerna', value: 'notSupported' },
@@ -116,6 +125,7 @@ const fast: Item[] = [
     tooltip: 'The ability to distribute a command across many machines.',
     features: [
       { title: 'Bazel', value: 'supported' },
+      { title: 'Earthly', value: 'notSupported' },
       { title: 'Gradle', value: 'manualImplementation' },
       { title: 'Lage', value: 'notSupported' },
       { title: 'Lerna', value: 'notSupported' },
@@ -131,6 +141,7 @@ const fast: Item[] = [
       'The ability to execute any command on multiple machines while developing locally.',
     features: [
       { title: 'Bazel', value: 'supported' },
+      { title: 'Earthly', value: 'supported' },
       { title: 'Gradle', value: 'notSupported' },
       { title: 'Lage', value: 'notSupported' },
       { title: 'Lerna', value: 'notSupported' },
@@ -146,6 +157,7 @@ const fast: Item[] = [
       'Determine what might be affected by a change, to run only build/test affected projects.',
     features: [
       { title: 'Bazel', value: 'manualImplementation' },
+      { title: 'Earthly', value: 'supported' },
       { title: 'Gradle', value: 'supported' },
       { title: 'Lage', value: 'supported' },
       { title: 'Lerna', value: 'supported' },
@@ -163,6 +175,7 @@ const understandable: Item[] = [
       'The ability to understand the understand the project graph of the workspace without extra configuration.',
     features: [
       { title: 'Bazel', value: 'manualImplementation' },
+      { title: 'Earthly', value: 'manualImplementation' },
       { title: 'Gradle', value: 'supported' },
       { title: 'Lage', value: 'supported' },
       { title: 'Nx', value: 'supported' },
@@ -178,6 +191,7 @@ const understandable: Item[] = [
       'Visualize dependency relationships between projects and/or tasks.',
     features: [
       { title: 'Bazel', value: 'supported' },
+      { title: 'Earthly', value: 'manualImplementation' },
       { title: 'Gradle', value: 'manualImplementation' },
       { title: 'Lage', value: 'manualImplementation' },
       { title: 'Lerna', value: 'manualImplementation' },
@@ -194,6 +208,7 @@ const manageable: Item[] = [
     tooltip: 'Facilitates sharing of discrete pieces source code.',
     features: [
       { title: 'Bazel', value: 'supported' },
+      { title: 'Earthly', value: 'supported' },
       { title: 'Gradle', value: 'supported' },
       { title: 'Lage', value: 'supported' },
       { title: 'Lerna', value: 'supported' },
@@ -209,6 +224,7 @@ const manageable: Item[] = [
       'The tool helps you get a consistent experience regardless of what you use to develop your projects: different JavaScript frameworks, Go, Java, etc.',
     features: [
       { title: 'Bazel', value: 'supported' },
+      { title: 'Earthly', value: 'supported' },
       { title: 'Gradle', value: 'supported' },
       { title: 'Lage', value: 'notSupported' },
       { title: 'Lerna', value: 'notSupported' },
@@ -223,6 +239,7 @@ const manageable: Item[] = [
     tooltip: 'Native support for generating code',
     features: [
       { title: 'Bazel', value: 'manualImplementation' },
+      { title: 'Earthly', value: 'manualImplementation' },
       { title: 'Gradle', value: 'manualImplementation' },
       { title: 'Lage', value: 'manualImplementation' },
       { title: 'Lerna', value: 'manualImplementation' },
@@ -238,6 +255,7 @@ const manageable: Item[] = [
       'Supports definition of rules to constrain dependency relationships within the repo.',
     features: [
       { title: 'Bazel', value: 'supported' },
+      { title: 'Earthly', value: 'manualImplementation' },
       { title: 'Gradle', value: 'manualImplementation' },
       { title: 'Lage', value: 'manualImplementation' },
       { title: 'Lerna', value: 'manualImplementation' },


### PR DESCRIPTION
Hi folks, 👋 

Really enjoyed the Monorepo.tools webpage. 

[Earthly](https://github.com/earthly/earthly) is another great build tool when working in a monorepo. Its built-in caching can speed up development since it only rebuilds sub-components of a monorepo that are affected by a change.

Earthly also has a sophisticated Dockerfile-like syntax that lets you script just about anything in terms of build steps, unit or integration tests, code analysis, etc. Everything runs in sandboxed containers too, so something like a build failure in CI can be easily reproduced and fixed on a dev machine.

Some examples of Earthly in a monorepo can be found [here](https://github.com/earthly/earthly/tree/main/examples/monorepo) and [here](https://github.com/earthly/earthly/tree/main/examples/go-monorepo).

I hope you'll find this a welcome addition to the webpage. Our fast-growing community of Earthly users actually suggested that we should be listed here.