### PR TITLE
refact(website): put tools logo on 2 grids

### DIFF
--- a/libs/website/ui-home/src/lib/monorepo-tools-logos.tsx
+++ b/libs/website/ui-home/src/lib/monorepo-tools-logos.tsx
@@ -1,4 +1,4 @@
-const tools: { name: string; link: string }[] = [
+const tools1: { name: string; link: string }[] = [
   // Alphabetical order
   {
     name: 'Bazel',
@@ -16,6 +16,9 @@ const tools: { name: string; link: string }[] = [
     name: 'Lerna',
     link: 'https://github.com/lerna/lerna?utm_source=monorepo.tools',
   },
+];
+const tools2: { name: string; link: string }[] = [
+  // Alphabetical order
   {
     name: 'Nx',
     link: 'https://github.com/nrwl/nx?utm_source=monorepo.tools',
@@ -36,20 +39,36 @@ const tools: { name: string; link: string }[] = [
 
 export function MonorepoToolsLogos() {
   return (
-    <div className="mt-8 grid grid-cols-1 gap-0.5 py-12 text-2xl font-semibold md:grid-cols-8 lg:mt-16 lg:py-16">
-      {tools.map((tool) => (
-        <a
-          key={'tool-' + tool.name}
-          href={tool.link}
-          title={tool.name + ' on Github'}
-          rel="noreferrer"
-          target="_blank"
-          className="col-span-1 flex justify-center rounded bg-slate-100 py-8 px-8 transition hover:bg-yellow-500 hover:text-gray-800 dark:bg-slate-900 hover:dark:bg-yellow-500"
-        >
-          {tool.name}
-        </a>
-      ))}
-    </div>
+    <>
+      <div className="mt-8 grid  grid-cols-4 gap-0.5 pt-12 text-lg font-semibold lg:mt-16 lg:pt-16 lg:text-2xl">
+        {tools1.map((tool) => (
+          <a
+            key={'tool-' + tool.name}
+            href={tool.link}
+            title={tool.name + ' on Github'}
+            rel="noreferrer"
+            target="_blank"
+            className="col-span-1 flex justify-center rounded bg-slate-100 py-8 px-8 transition hover:bg-yellow-500 hover:text-gray-800 dark:bg-slate-900 hover:dark:bg-yellow-500"
+          >
+            {tool.name}
+          </a>
+        ))}
+      </div>
+      <div className="mt-4 grid grid-cols-4 gap-0.5 pb-12 text-lg font-semibold lg:mb-16 lg:pb-16 lg:text-2xl">
+        {tools2.map((tool) => (
+          <a
+            key={'tool-' + tool.name}
+            href={tool.link}
+            title={tool.name + ' on Github'}
+            rel="noreferrer"
+            target="_blank"
+            className="col-span-1 flex justify-center rounded bg-slate-100 py-8 px-8 transition hover:bg-yellow-500 hover:text-gray-800 dark:bg-slate-900 hover:dark:bg-yellow-500"
+          >
+            {tool.name}
+          </a>
+        ))}
+      </div>
+    </>
   );
 }
 


### PR DESCRIPTION
It splits the one large grid showing tools links into two grids that fit better on mobile.