### PR TITLE
chore(core): remove duplicated word

### DIFF
--- a/libs/website/ui-home/src/lib/tools-review.tsx
+++ b/libs/website/ui-home/src/lib/tools-review.tsx
@@ -345,7 +345,7 @@ export function ToolsReview() {
                   {tool.title}{' '}
                   {tool.organization ? (
                     <span className="ml-2 text-xs font-normal">
-                      (by {tool.organization})
+                      ({tool.organization})
                     </span>
                   ) : null}
                 </h3>


### PR DESCRIPTION
Each tool's maintaining/owning organization attribution in the Tools Review section appears as "{tool} (by by {organization})". This PR removes the extra "by" that was missed in the changes made in #80 