### PR TITLE
chore(libs/website/ui-home): added a space after a highlighted word

### DIFF
--- a/libs/website/ui-home/src/lib/introduction.tsx
+++ b/libs/website/ui-home/src/lib/introduction.tsx
@@ -47,7 +47,7 @@ export function Introduction(): JSX.Element {
                 <mark className="rounded-md bg-yellow-500 px-1">
                   what benefits
                 </mark>
-                they can bring, and the{' '}
+                {' '}they can bring, and the{' '}
                 <mark className="rounded-md bg-yellow-500 px-1">
                   tools available
                 </mark>{' '}


### PR DESCRIPTION
The highlighted word "what benefits" and the unhighlighted word "they can bring" had no space in-between, so I added a space to fix this typo