### PR TITLE
fix: show synthetic-monorepo and CI pipeline animations on mobile

### DIFF
--- a/libs/website/ui-ai/src/lib/ci-pipeline-animation.tsx
+++ b/libs/website/ui-ai/src/lib/ci-pipeline-animation.tsx
@@ -632,7 +632,7 @@ export function CiPipelineAnimation() {
       />
 
       {/* Description boxes */}
-      <div className="mt-10 grid grid-cols-2 gap-6">
+      <div className="mt-10 grid grid-cols-1 gap-6 md:grid-cols-2">
         <div className="flex min-h-[200px] flex-col rounded-md border border-slate-200 bg-slate-100 p-5 dark:border-black dark:bg-slate-900">
           <p className="text-lg font-medium text-gray-900 dark:text-white">
             Distributed Task Execution

--- a/libs/website/ui-ai/src/lib/ci-pressure.tsx
+++ b/libs/website/ui-ai/src/lib/ci-pressure.tsx
@@ -40,7 +40,7 @@ export function CIPressure(): JSX.Element {
         </div>
 
         {/* CI Pipeline Bottleneck Animation */}
-        <div className="mt-16 hidden md:block">
+        <div className="mt-16">
           <div className="mx-auto max-w-4xl">
             <CiPipelineAnimation />
           </div>

--- a/libs/website/ui-synthetic-monorepos/src/lib/ai-agents-across-boundaries.tsx
+++ b/libs/website/ui-synthetic-monorepos/src/lib/ai-agents-across-boundaries.tsx
@@ -44,7 +44,7 @@ export function AIAgentsAcrossBoundaries(): JSX.Element {
             </p>
           </div>
 
-          <div className="mt-8 hidden md:block lg:mt-0">
+          <div className="mt-8 lg:mt-0">
             <SyntheticMonorepoAnimation alwaysSynthetic />
           </div>
         </div>

--- a/libs/website/ui-synthetic-monorepos/src/lib/ai-local-optimization.tsx
+++ b/libs/website/ui-synthetic-monorepos/src/lib/ai-local-optimization.tsx
@@ -7,10 +7,6 @@ export function AILocalOptimization(): JSX.Element {
     <div className="overflow-hidden bg-white py-16 lg:py-24 dark:bg-slate-900">
       <div className="relative mx-auto max-w-xl px-4 sm:px-6 lg:max-w-7xl lg:px-8">
         <div className="lg:grid lg:grid-cols-2 lg:items-center lg:gap-12">
-          <div className="hidden md:block">
-            <IsolatedAgentsAnimation />
-          </div>
-
           <div id="ai-local-optimization">
             <h2
               id="local-optimizations"
@@ -40,6 +36,10 @@ export function AILocalOptimization(): JSX.Element {
               </span>
               . That breaks agent autonomy.
             </p>
+          </div>
+
+          <div className="mt-8 lg:order-first lg:mt-0">
+            <IsolatedAgentsAnimation />
           </div>
         </div>
       </div>

--- a/libs/website/ui-synthetic-monorepos/src/lib/isolated-agents-animation.tsx
+++ b/libs/website/ui-synthetic-monorepos/src/lib/isolated-agents-animation.tsx
@@ -104,8 +104,9 @@ export function IsolatedAgentsAnimation() {
     const dpr = window.devicePixelRatio || 1;
     canvas.width = CANVAS_W * dpr;
     canvas.height = CANVAS_H * dpr;
-    canvas.style.width = `${CANVAS_W}px`;
-    canvas.style.height = `${CANVAS_H}px`;
+    canvas.style.width = '100%';
+    canvas.style.height = 'auto';
+    canvas.style.maxWidth = `${CANVAS_W}px`;
     ctx.scale(dpr, dpr);
 
     canvas.addEventListener('mousemove', handleMouseMove);

--- a/libs/website/ui-synthetic-monorepos/src/lib/polyrepo-islands-animation.tsx
+++ b/libs/website/ui-synthetic-monorepos/src/lib/polyrepo-islands-animation.tsx
@@ -130,8 +130,9 @@ export function PolyrepoIslandsAnimation() {
     const dpr = window.devicePixelRatio || 1;
     canvas.width = CANVAS_W * dpr;
     canvas.height = CANVAS_H * dpr;
-    canvas.style.width = `${CANVAS_W}px`;
-    canvas.style.height = `${CANVAS_H}px`;
+    canvas.style.width = '100%';
+    canvas.style.height = 'auto';
+    canvas.style.maxWidth = `${CANVAS_W}px`;
     ctx.scale(dpr, dpr);
 
     canvas.addEventListener('mousemove', handleMouseMove);

--- a/libs/website/ui-synthetic-monorepos/src/lib/polyrepo-reality.tsx
+++ b/libs/website/ui-synthetic-monorepos/src/lib/polyrepo-reality.tsx
@@ -49,7 +49,7 @@ export function PolyrepoReality(): JSX.Element {
             </p>
           </div>
 
-          <div className="mt-8 hidden md:block lg:mt-0">
+          <div className="mt-8 lg:mt-0">
             <PolyrepoIslandsAnimation />
           </div>
         </div>

--- a/libs/website/ui-synthetic-monorepos/src/lib/synthetic-monorepo-animation.tsx
+++ b/libs/website/ui-synthetic-monorepos/src/lib/synthetic-monorepo-animation.tsx
@@ -400,8 +400,9 @@ export function SyntheticMonorepoAnimation({ alwaysSynthetic = false }: { always
     const dpr = window.devicePixelRatio || 1;
     canvas.width = CANVAS_W * dpr;
     canvas.height = CANVAS_H * dpr;
-    canvas.style.width = `${CANVAS_W}px`;
-    canvas.style.height = `${CANVAS_H}px`;
+    canvas.style.width = '100%';
+    canvas.style.height = 'auto';
+    canvas.style.maxWidth = `${CANVAS_W}px`;
     ctx.scale(dpr, dpr);
 
     canvas.addEventListener('mousemove', handleMouseMove);

--- a/libs/website/ui-synthetic-monorepos/src/lib/what-synthetic-monorepos-provide.tsx
+++ b/libs/website/ui-synthetic-monorepos/src/lib/what-synthetic-monorepos-provide.tsx
@@ -45,7 +45,7 @@ export function WhatSyntheticMonoreposProvide(): JSX.Element {
         </div>
 
         {/* Connected animation */}
-        <div className="mx-auto mt-12 hidden max-w-2xl md:block lg:mt-16">
+        <div className="mx-auto mt-12 max-w-2xl lg:mt-16">
           <SyntheticMonorepoAnimation />
         </div>
 


### PR DESCRIPTION
## Summary

Animations on /synthetic-monorepos and the CI section of /ai were hidden below the `md` breakpoint.

- /synthetic-monorepos canvases: `width: 100%`, `height: auto`, `max-width` capped at design size (keeps DPR-scaled backing buffer; mouse math already used `rect.width`).
- /ai CI pipeline animation: wrapper was `hidden md:block`; canvas itself was already responsive (`w-full h-72 md:h-80`).
- Dropped `hidden md:block` on all affected wrappers.
- `ai-local-optimization`: reordered DOM so text appears first on mobile; `lg:order-first` restores animation-left layout on desktop.