### PR TITLE
fix(conf): replace TBD with 'full schedule coming soon' in agenda

### DIFF
--- a/libs/website/ui-conf/src/lib/ai/agenda.tsx
+++ b/libs/website/ui-conf/src/lib/ai/agenda.tsx
@@ -44,18 +44,19 @@ export function Agenda() {
             marginBottom: 18,
           }}
         >
-          SCHEDULE · COMING SOON
+          SCHEDULE
         </div>
         <div
-          className="mb-4 text-[40px] tracking-[-1px] md:text-[64px] md:tracking-[-2px]"
+          className="mb-4 text-[32px] tracking-[-1px] md:text-[56px] md:tracking-[-2px]"
           style={{
             fontFamily: FONTS.display,
             fontWeight: 700,
             color: PALETTE.text,
-            lineHeight: 1,
+            lineHeight: 0.95,
           }}
         >
-          TBD
+          Full schedule{' '}
+          <span style={{ color: PALETTE.pink }}>coming soon</span>
         </div>
         <p
           style={{


### PR DESCRIPTION
## Summary
Replace the odd `TBD` placeholder in the AI conf agenda with a 'Full schedule coming soon' headline, sized to sit below the section title without competing.

<img width="1768" height="659" alt="image" src="https://github.com/user-attachments/assets/58d1f72e-2a10-4222-bc46-5f8f42246477" />
