### PR TITLE
fix(conf): use consistent 'June 23, 2026' date format on AI conf page

### DIFF
--- a/libs/website/ui-conf/src/lib/ai/ai-conf-page-badge.tsx
+++ b/libs/website/ui-conf/src/lib/ai/ai-conf-page-badge.tsx
@@ -80,7 +80,7 @@ export function AiConfPageBadge() {
             background: PALETTE.bgDeeper,
           }}
         >
-          <Stat label="DATE" value="23rd June 2026" tone={PALETTE.pink} />
+          <Stat label="DATE" value="June 23, 2026" tone={PALETTE.pink} />
           <div className="md:justify-self-center">
             <Stat label="FORMAT" value="Online, free" tone={PALETTE.cyan} />
           </div>

--- a/libs/website/ui-conf/src/lib/ai/ai-conf-page.tsx
+++ b/libs/website/ui-conf/src/lib/ai/ai-conf-page.tsx
@@ -49,7 +49,7 @@ export function AiConfPage() {
           background: PALETTE.bgDeeper,
         }}
       >
-        <Stat label="DATE" value="23rd June 2026" tone={PALETTE.pink} />
+        <Stat label="DATE" value="June 23, 2026" tone={PALETTE.pink} />
         <div className="md:justify-self-center">
           <Stat label="FORMAT" value="Online, free" tone={PALETTE.cyan} />
         </div>

--- a/libs/website/ui-conf/src/lib/ai/ai-conf-speaker-page.tsx
+++ b/libs/website/ui-conf/src/lib/ai/ai-conf-speaker-page.tsx
@@ -114,7 +114,7 @@ export function AiConfSpeakerPage({ speaker }: { speaker: Speaker }) {
           background: PALETTE.bgDeeper,
         }}
       >
-        <Stat label="DATE" value="23rd June 2026" tone={PALETTE.pink} />
+        <Stat label="DATE" value="June 23, 2026" tone={PALETTE.pink} />
         <div className="md:justify-self-center">
           <Stat label="FORMAT" value="Online, free" tone={PALETTE.cyan} />
         </div>


### PR DESCRIPTION
## What

The DATE `Stat` on the AI conf page, badge, and speaker page read `23rd June 2026`, while the rest of the site uses `June 23, 2026`.

This aligns all three to the site-wide format.

## Changes

- `libs/website/ui-conf/src/lib/ai/ai-conf-page-badge.tsx`
- `libs/website/ui-conf/src/lib/ai/ai-conf-page.tsx`
- `libs/website/ui-conf/src/lib/ai/ai-conf-speaker-page.tsx`

Each changed `value="23rd June 2026"` → `value="June 23, 2026"`.

## Why

Consistency with the existing `June 23, 2026` format already used in `hero.tsx`, `ai/data.ts`, `register-cta.tsx`, `agenda.tsx`, and the conf page metadata.

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/date-correction-3cfdbed1)
<!-- polygraph-session-end -->