### PR TITLE
fix(conf): add Kiet talk teaser + show org on speaker badge

### DIFF
--- a/libs/website/ui-conf/src/lib/ai/agenda.tsx
+++ b/libs/website/ui-conf/src/lib/ai/agenda.tsx
@@ -8,6 +8,8 @@ const TALK_TEASERS: Record<string, string> = {
     "If agents take over the implementation, judgment is what's left. Kent on what stays most human and valuable in an AI era.",
   'jack-herrington':
     'Code mode as a new approach to agentic AI: drastically fewer tokens, far higher accuracy. Jack shows the results.',
+  'kiet-ho':
+    "More agents doesn't mean more output. Kiet on a Lean Manufacturing framework for where to apply and tune agent usage at scale.",
   'nicolas-beaussart':
     'PayFit ripped out micro-frontends across 15+ repos and cut CI from 45 to 5 minutes. Nicolas on the consolidation playbook.',
 };

--- a/libs/website/ui-conf/src/lib/ai/badge-hero.tsx
+++ b/libs/website/ui-conf/src/lib/ai/badge-hero.tsx
@@ -68,7 +68,9 @@ export type BadgeContent = {
 export function speakerBadgeContent(speaker: Speaker): BadgeContent {
   return {
     name: speaker.name,
-    role: speaker.role,
+    // Include the company so the role reads e.g. "Co-Founder · Superset"
+    // instead of an orphaned title with no context.
+    role: speaker.org ? `${speaker.role} · ${speaker.org}` : speaker.role,
     bannerLabel: 'SPEAKER',
     image: speaker.image,
   };
@@ -234,9 +236,16 @@ async function buildBadgeTexture(
     ctx.font = `700 ${nameSize}px "Space Grotesk", "Inter", sans-serif`;
   }
 
+  // role auto-shrinks too, since "Role · Org" can run wider than the card.
+  let roleSize = 30;
+  ctx.font = `500 ${roleSize}px "JetBrains Mono", monospace`;
+  while (ctx.measureText(content.role).width > maxNameW && roleSize > 18) {
+    roleSize -= 1;
+    ctx.font = `500 ${roleSize}px "JetBrains Mono", monospace`;
+  }
+
   // center the name+role group on the avatar center (blockCY) using real glyph
   // metrics, so it stays aligned regardless of how far the name shrank.
-  const roleSize = 30;
   const nameFont = `700 ${nameSize}px "Space Grotesk", "Inter", sans-serif`;
   const roleFont = `500 ${roleSize}px "JetBrains Mono", monospace`;
   const GAP = 46; // name baseline → role baseline


### PR DESCRIPTION
## Summary

- Add `kiet-ho` entry to the confirmed-talks `TALK_TEASERS` map. His card was rendering only the talk title with no summary because teasers are keyed by speaker id and he was missing.
- Speaker share badge now shows `Role · Org` (e.g. "Co-Founder · Superset") instead of an orphaned title with no company context.
- Add auto-shrink to the badge role text so longer `Role · Org` strings fit the card width (the name already auto-shrank; the role did not).

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/speaker-updates-14b12557)
<!-- polygraph-session-end -->