### PR TITLE
fix(conf): make talk dialog full-width on mobile

### DIFF
--- a/libs/website/ui-conf/src/lib/ai/shared.tsx
+++ b/libs/website/ui-conf/src/lib/ai/shared.tsx
@@ -541,6 +541,26 @@ export function SpeakerModal({
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
   }, [speaker, onClose]);
+  useEffect(() => {
+    if (!speaker || typeof document === 'undefined') return;
+    const { body, documentElement } = document;
+    const prevBodyOverflow = body.style.overflow;
+    const prevBodyOverscroll = body.style.overscrollBehavior;
+    const prevHtmlOverflow = documentElement.style.overflow;
+    const prevHtmlOverscroll = documentElement.style.overscrollBehavior;
+
+    body.style.overflow = 'hidden';
+    body.style.overscrollBehavior = 'none';
+    documentElement.style.overflow = 'hidden';
+    documentElement.style.overscrollBehavior = 'none';
+
+    return () => {
+      body.style.overflow = prevBodyOverflow;
+      body.style.overscrollBehavior = prevBodyOverscroll;
+      documentElement.style.overflow = prevHtmlOverflow;
+      documentElement.style.overscrollBehavior = prevHtmlOverscroll;
+    };
+  }, [speaker]);
   if (!speaker) return null;
   const shareUrl =
     typeof window !== 'undefined'
@@ -549,7 +569,7 @@ export function SpeakerModal({
   return (
     <div
       onClick={onClose}
-      className="p-4 md:p-10"
+      className="p-0 md:p-10"
       style={{
         position: 'fixed',
         inset: 0,
@@ -563,12 +583,15 @@ export function SpeakerModal({
     >
       <div
         onClick={(e) => e.stopPropagation()}
-        className="grid max-h-[90vh] grid-cols-1 overflow-y-auto md:grid-cols-[360px_1fr]"
+        className="grid h-[100dvh] max-h-[100dvh] w-full grid-cols-1 overflow-y-auto overscroll-contain md:h-auto md:max-h-[90vh] md:grid-cols-[360px_1fr]"
         style={{
-          width: 'min(1080px, 100%)',
+          width: '100%',
+          maxWidth: 1080,
+          boxSizing: 'border-box',
           background: PALETTE.bg,
           border: `1px solid ${PALETTE.bgLine}`,
           position: 'relative',
+          overscrollBehavior: 'contain',
         }}
       >
         <div


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- make the speaker/talk modal use edge-to-edge width on mobile by removing mobile overlay padding
- make the modal container fill mobile viewport height (`100dvh`) and keep desktop sizing unchanged
- contain overscroll in the modal and lock document/body scrolling while the modal is open to prevent accidental background/page scrolling

## Testing
- not run (workspace dependencies are not installed in this cloud environment; `yarn nx`/`pnpm nx` commands are unavailable without install)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-139bab93-6b09-406c-ade7-a68504e570f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-139bab93-6b09-406c-ade7-a68504e570f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

