### PR TITLE
Add explicit Twitter images for conf cards

### DIFF
--- a/apps/website/pages/conf.tsx
+++ b/apps/website/pages/conf.tsx
@@ -1,26 +1,30 @@
 import { AiConfPageBadge } from '@monorepo-tools/website/ui-conf';
 import { NextSeo } from 'next-seo';
+import Head from 'next/head';
 import { useRouter } from 'next/router';
 
 export function Index() {
   const router = useRouter();
+  const title = 'AI ❤️ Monorepos · Conf 2026';
+  const description =
+    'A free half-day virtual conference for engineers working at the intersection of monorepos, CI, and agentic AI. June 23, 2026.';
+  const image = 'https://monorepo.tools/images/conf/og/conf.png';
 
   return (
     <>
       <NextSeo
-        title="AI ❤️ Monorepos · Conf 2026"
-        description="A free half-day virtual conference for engineers working at the intersection of monorepos, CI, and agentic AI. June 23, 2026."
+        title={title}
+        description={description}
         openGraph={{
           url: `https://monorepo.tools${router.asPath}`,
-          title: 'AI ❤️ Monorepos · Conf 2026',
-          description:
-            'A free half-day virtual conference for engineers working at the intersection of monorepos, CI, and agentic AI. June 23, 2026.',
+          title,
+          description,
           images: [
             {
-              url: 'https://monorepo.tools/images/conf/og/conf.png',
+              url: image,
               width: 1200,
               height: 630,
-              alt: 'AI ❤️ Monorepos · Conf 2026',
+              alt: title,
               type: 'image/png',
             },
           ],
@@ -32,6 +36,16 @@ export function Index() {
           cardType: 'summary_large_image',
         }}
       />
+      <Head>
+        <meta key="twitter-title" name="twitter:title" content={title} />
+        <meta
+          key="twitter-description"
+          name="twitter:description"
+          content={description}
+        />
+        <meta key="twitter-image" name="twitter:image" content={image} />
+        <meta key="twitter-image-alt" name="twitter:image:alt" content={title} />
+      </Head>
       <AiConfPageBadge />
     </>
   );

--- a/apps/website/pages/conf.tsx
+++ b/apps/website/pages/conf.tsx
@@ -8,7 +8,7 @@ export function Index() {
   const title = 'AI ❤️ Monorepos · Conf 2026';
   const description =
     'A free half-day virtual conference for engineers working at the intersection of monorepos, CI, and agentic AI. June 23, 2026.';
-  const image = 'https://monorepo.tools/images/conf/og/conf.png';
+  const image = 'https://monorepo.tools/images/conf/og/conf.png?v=20260604';
 
   return (
     <>

--- a/apps/website/pages/conf/speaker/[id].tsx
+++ b/apps/website/pages/conf/speaker/[id].tsx
@@ -4,6 +4,7 @@ import {
   Speaker,
 } from '@monorepo-tools/website/ui-conf';
 import { NextSeo } from 'next-seo';
+import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { GetStaticPaths, GetStaticProps } from 'next';
 
@@ -41,6 +42,20 @@ export function SpeakerPage({ speaker }: { speaker: Speaker }) {
           cardType: 'summary_large_image',
         }}
       />
+      <Head>
+        <meta key="twitter-title" name="twitter:title" content={title} />
+        <meta
+          key="twitter-description"
+          name="twitter:description"
+          content={description}
+        />
+        <meta key="twitter-image" name="twitter:image" content={image} />
+        <meta
+          key="twitter-image-alt"
+          name="twitter:image:alt"
+          content={speaker.name}
+        />
+      </Head>
       <AiConfSpeakerPage speaker={speaker} />
     </>
   );

--- a/apps/website/pages/conf/speaker/[id].tsx
+++ b/apps/website/pages/conf/speaker/[id].tsx
@@ -14,7 +14,7 @@ export function SpeakerPage({ speaker }: { speaker: Speaker }) {
   const description = speaker.talkTitle
     ? `${speaker.name} — "${speaker.talkTitle}". ${speaker.bio}`
     : `${speaker.name}, ${speaker.role} at ${speaker.org}. ${speaker.bio}`;
-  const image = `https://monorepo.tools/images/conf/og/${speaker.id}.png`;
+  const image = `https://monorepo.tools/images/conf/og/${speaker.id}.png?v=20260604`;
 
   return (
     <>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add explicit Twitter card title, description, image, and image alt tags for `/conf`
- add the same Twitter image metadata for conference speaker pages
- keep the existing PNG Open Graph assets as the source image
- version the social image URLs with `?v=20260604` so X sees a fresh image URL instead of a previously cached failed/placeholder fetch

## Verification
- Confirmed the live `/conf` page currently points at a PNG OG image, not AVIF
- Confirmed `https://monorepo.tools/images/conf/og/conf.png` returns `200 OK`, `content-type: image/png`, 1200x630, 89 KB, including as `Twitterbot/1.0`
- Confirmed the versioned image URL returns `200 OK`, `content-type: image/png`
- `pnpm nx lint website`
- `pnpm nx build website`
- Confirmed generated HTML contains versioned `twitter:image` and `og:image` tags for `/conf` and `/conf/speaker/jeff-cross`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-26fb0c1c-23ec-41f1-86d2-655ffc3bf3e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26fb0c1c-23ec-41f1-86d2-655ffc3bf3e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

