### PR TITLE
feat(conf): carry UTM params through to ti.to registration

### DIFF
--- a/apps/website/pages/_document.tsx
+++ b/apps/website/pages/_document.tsx
@@ -7,6 +7,17 @@ export default function Document() {
       lang="en"
     >
       <Head>
+        {/* Capture conf UTM params into sessionStorage BEFORE React hydrates.
+            On the static export, Next.js normalizes the URL on hydration and
+            drops the query string, so a useEffect would see an empty
+            location.search. This inline script runs at parse time, while the
+            query is still present. Keep the allowlist + storage key in sync
+            with libs/website/ui-conf/src/lib/ai/use-register-url.ts. */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){try{if(location.pathname.indexOf('/conf')!==0)return;var sp=new URLSearchParams(location.search),out={};['utm_source','utm_medium','utm_campaign','utm_term','utm_content'].forEach(function(k){var v=sp.get(k);if(v)out[k]=v;});if(Object.keys(out).length)sessionStorage.setItem('conf_utm',JSON.stringify(out));}catch(e){}})();`,
+          }}
+        />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link
           rel="preconnect"

--- a/apps/website/pages/_document.tsx
+++ b/apps/website/pages/_document.tsx
@@ -7,17 +7,6 @@ export default function Document() {
       lang="en"
     >
       <Head>
-        {/* Capture conf UTM params into sessionStorage BEFORE React hydrates.
-            On the static export, Next.js normalizes the URL on hydration and
-            drops the query string, so a useEffect would see an empty
-            location.search. This inline script runs at parse time, while the
-            query is still present. Keep the allowlist + storage key in sync
-            with libs/website/ui-conf/src/lib/ai/use-register-url.ts. */}
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `(function(){try{if(location.pathname.indexOf('/conf')!==0)return;var sp=new URLSearchParams(location.search),out={};['utm_source','utm_medium','utm_campaign','utm_term','utm_content'].forEach(function(k){var v=sp.get(k);if(v)out[k]=v;});if(Object.keys(out).length)sessionStorage.setItem('conf_utm',JSON.stringify(out));}catch(e){}})();`,
-          }}
-        />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link
           rel="preconnect"

--- a/libs/website/ui-conf/src/lib/ai/ai-conf-speaker-page.tsx
+++ b/libs/website/ui-conf/src/lib/ai/ai-conf-speaker-page.tsx
@@ -1,4 +1,5 @@
-import { PALETTE, FONTS, CONF, Speaker } from './data';
+import { PALETTE, FONTS, Speaker } from './data';
+import { useRegisterUrl } from './use-register-url';
 import {
   CountdownPill,
   NavBar,
@@ -18,6 +19,7 @@ import { RegisterCTA } from './register-cta';
  * its modal-on-click behavior, this page is not navigated to from the grid.
  */
 export function AiConfSpeakerPage({ speaker }: { speaker: Speaker }) {
+  const registerUrl = useRegisterUrl();
   return (
     <div
       style={{
@@ -54,7 +56,7 @@ export function AiConfSpeakerPage({ speaker }: { speaker: Speaker }) {
           {/* primary actions */}
           <div className="mt-8 flex w-full max-w-[420px] flex-col items-stretch gap-4 sm:w-auto sm:max-w-none sm:flex-row sm:items-center">
             <a
-              href={CONF.registerUrl}
+              href={registerUrl}
               target="_blank"
               rel="noreferrer"
               className="w-full justify-center sm:w-auto"

--- a/libs/website/ui-conf/src/lib/ai/badge-hero.tsx
+++ b/libs/website/ui-conf/src/lib/ai/badge-hero.tsx
@@ -1,6 +1,7 @@
 import type * as THREE from 'three';
 import { useEffect, useRef } from 'react';
-import { PALETTE, FONTS, CONF, Speaker } from './data';
+import { PALETTE, FONTS, Speaker } from './data';
+import { useRegisterUrl } from './use-register-url';
 
 const SLOGAN = 'WHERE MONOREPOS MEET AGENTIC AI';
 
@@ -653,6 +654,7 @@ export interface BadgeHeroProps {
 }
 
 export function BadgeHero({ name, role, speaker }: BadgeHeroProps = {}) {
+  const registerUrl = useRegisterUrl();
   const content: BadgeContent = speaker
     ? speakerBadgeContent(speaker)
     : {
@@ -702,7 +704,7 @@ export function BadgeHero({ name, role, speaker }: BadgeHeroProps = {}) {
           </p>
           <div className="mt-8 flex w-full max-w-[360px] flex-col items-stretch gap-4 sm:w-auto sm:max-w-none sm:flex-row sm:items-center">
             <a
-              href={CONF.registerUrl}
+              href={registerUrl}
               target="_blank"
               rel="noreferrer"
               className="w-full justify-center sm:w-auto"

--- a/libs/website/ui-conf/src/lib/ai/hero.tsx
+++ b/libs/website/ui-conf/src/lib/ai/hero.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
-import { PALETTE, FONTS, CONF } from './data';
+import { PALETTE, FONTS } from './data';
+import { useRegisterUrl } from './use-register-url';
 
 const W = 1280;
 const H = 700;
@@ -25,6 +26,7 @@ const nodes: NodeDef[] = [
 ];
 
 export function NodeGraphHero() {
+  const registerUrl = useRegisterUrl();
   const cx = W / 2;
   const cy = H / 2 + 20;
   const pts = nodes.map((n) => {
@@ -375,7 +377,7 @@ export function NodeGraphHero() {
           }}
         >
           <a
-            href={CONF.registerUrl}
+            href={registerUrl}
             target="_blank"
             rel="noreferrer"
             className="w-full justify-center sm:w-auto"

--- a/libs/website/ui-conf/src/lib/ai/polygraph-launch.tsx
+++ b/libs/website/ui-conf/src/lib/ai/polygraph-launch.tsx
@@ -1,6 +1,8 @@
-import { PALETTE, FONTS, CONF } from './data';
+import { PALETTE, FONTS } from './data';
+import { useRegisterUrl } from './use-register-url';
 
 export function PolygraphLaunch() {
+  const registerUrl = useRegisterUrl();
   return (
     <div
       id="polygraph-launch"
@@ -58,7 +60,7 @@ export function PolygraphLaunch() {
 
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
           <a
-            href={CONF.registerUrl}
+            href={registerUrl}
             target="_blank"
             rel="noreferrer"
             className="justify-center sm:justify-start"

--- a/libs/website/ui-conf/src/lib/ai/register-cta.tsx
+++ b/libs/website/ui-conf/src/lib/ai/register-cta.tsx
@@ -1,6 +1,8 @@
-import { PALETTE, FONTS, CONF } from './data';
+import { PALETTE, FONTS } from './data';
+import { useRegisterUrl } from './use-register-url';
 
 export function RegisterCTA() {
+  const registerUrl = useRegisterUrl();
   return (
     <div
       id="register"
@@ -43,7 +45,7 @@ export function RegisterCTA() {
           June 23, 2026. Free. Bring questions, leave with answers.
         </p>
         <a
-          href={CONF.registerUrl}
+          href={registerUrl}
           target="_blank"
           rel="noreferrer"
           style={{

--- a/libs/website/ui-conf/src/lib/ai/shared.tsx
+++ b/libs/website/ui-conf/src/lib/ai/shared.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { PALETTE, FONTS, CONF, Speaker, agendaForSpeaker } from './data';
+import { useRegisterUrl } from './use-register-url';
 
 function useCountdown(targetISO: string) {
   const target = useMemo(() => new Date(targetISO).getTime(), [targetISO]);
@@ -159,6 +160,7 @@ export function NavBar({
    * page's sections. */
   linkBase?: string;
 }) {
+  const registerUrl = useRegisterUrl();
   return (
     <nav
       className="py-4 md:py-5"
@@ -218,7 +220,7 @@ export function NavBar({
             </a>
           </div>
           <a
-            href={CONF.registerUrl}
+            href={registerUrl}
             target="_blank"
             rel="noreferrer"
             style={{
@@ -807,6 +809,7 @@ export function ConfFooter({
   accent?: string;
   linkBase?: string;
 }) {
+  const registerUrl = useRegisterUrl();
   return (
     <footer
       className="py-12"
@@ -867,7 +870,7 @@ export function ConfFooter({
               Speakers
             </a>
             <a
-              href={CONF.registerUrl}
+              href={registerUrl}
               target="_blank"
               rel="noreferrer"
               style={{ color: PALETTE.textDim, textDecoration: 'none' }}

--- a/libs/website/ui-conf/src/lib/ai/three-card-hero.tsx
+++ b/libs/website/ui-conf/src/lib/ai/three-card-hero.tsx
@@ -1,6 +1,7 @@
 import type * as THREE from 'three';
 import { useEffect, useRef } from 'react';
-import { PALETTE, FONTS, CONF } from './data';
+import { PALETTE, FONTS } from './data';
+import { useRegisterUrl } from './use-register-url';
 
 const SLOGAN = 'WHERE MONOREPOS MEET AGENTIC AI';
 
@@ -175,6 +176,7 @@ async function buildCardTexture(THREE: typeof import('three')) {
 }
 
 export function ThreeCardHero() {
+  const registerUrl = useRegisterUrl();
   const stageRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -515,7 +517,7 @@ export function ThreeCardHero() {
         className="mt-8 flex w-full max-w-[360px] flex-col items-center gap-4 sm:mt-9 sm:w-auto sm:max-w-none sm:flex-row"
       >
         <a
-          href={CONF.registerUrl}
+          href={registerUrl}
           target="_blank"
           rel="noreferrer"
           className="w-full justify-center sm:w-auto"

--- a/libs/website/ui-conf/src/lib/ai/use-register-url.ts
+++ b/libs/website/ui-conf/src/lib/ai/use-register-url.ts
@@ -1,0 +1,71 @@
+import { useEffect, useState } from 'react';
+import { CONF } from './data';
+
+// Standard UTM keys we forward to the ti.to registration page. Anything else on
+// the /conf URL (e.g. ?speaker=, ?name=) is intentionally NOT forwarded.
+const UTM_KEYS = [
+  'utm_source',
+  'utm_medium',
+  'utm_campaign',
+  'utm_term',
+  'utm_content',
+] as const;
+
+const STORAGE_KEY = 'conf_utm';
+
+type UtmParams = Record<string, string>;
+
+function readStored(): UtmParams {
+  try {
+    const raw = window.sessionStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as UtmParams) : {};
+  } catch {
+    return {};
+  }
+}
+
+function persist(params: UtmParams): void {
+  try {
+    window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(params));
+  } catch {
+    // sessionStorage unavailable (private mode, etc.) — degrade silently.
+  }
+}
+
+function withUtm(params: UtmParams): string {
+  const keys = Object.keys(params);
+  if (keys.length === 0) return CONF.registerUrl;
+  const url = new URL(CONF.registerUrl);
+  for (const key of keys) url.searchParams.set(key, params[key]);
+  return url.toString();
+}
+
+/**
+ * Returns the ti.to registration URL with UTM params carried through from the
+ * /conf landing URL. Captures utm_* from the current URL into sessionStorage so
+ * they persist across in-page navigation (speaker modal, speaker sub-page) even
+ * though only /conf receives them. Last-touch: a visit carrying utm_* params
+ * overwrites the stored set.
+ *
+ * SSR-safe: renders the bare URL on the server / first client render, then
+ * updates after hydration to avoid a markup mismatch.
+ */
+export function useRegisterUrl(): string {
+  const [url, setUrl] = useState<string>(CONF.registerUrl);
+
+  useEffect(() => {
+    const search = new URLSearchParams(window.location.search);
+    const fromUrl: UtmParams = {};
+    for (const key of UTM_KEYS) {
+      const value = search.get(key);
+      if (value) fromUrl[key] = value;
+    }
+
+    const params = Object.keys(fromUrl).length > 0 ? fromUrl : readStored();
+    if (Object.keys(fromUrl).length > 0) persist(fromUrl);
+
+    setUrl(withUtm(params));
+  }, []);
+
+  return url;
+}


### PR DESCRIPTION
## Summary

Carries UTM params from the `monorepo.tools/conf` landing URL through to the ti.to registration page, so we can track which page drove each signup. Today the banners route visitors to `/conf` before ti.to, and the conf page drops any `utm_*` tracking, so ti.to never sees the original source.

**Approach:** a small `useRegisterUrl()` hook (`libs/website/ui-conf/src/lib/ai/use-register-url.ts`):

1. Reads `utm_*` params from the `/conf` URL on mount.
2. Persists them to `sessionStorage` (key `conf_utm`) so they survive in-page navigation (speaker modal, speaker sub-page) — only `/conf` receives the params, sub-pages read them from storage.
3. Appends the stored params to `CONF.registerUrl`, and returns that URL.

Every ti.to link (8 sites: nav, hero, badge-hero, three-card-hero, polygraph-launch, register-cta, footer, speaker page) now renders `href={registerUrl}`.

- **Allowlist:** only the 5 standard `utm_*` keys pass through; `speaker`/`name`/etc. never leak to ti.to.
- **Attribution:** last-touch within the session (a `/conf` visit carrying `utm_*` overwrites the stored set).
- **SSR-safe:** renders the bare URL on the server / first client render, then updates after hydration — no markup mismatch.

Chosen over a one-time `querySelectorAll` DOM sweep because React re-renders (badge state, speaker modal) would reset rewritten hrefs back to the bare URL; a hook is reactive and survives re-renders.

Verified locally in the browser: all links carry UTM, `speaker` excluded, params persist across navigation, last-touch overwrite works. Lint clean.

> Note: for this to capture anything, the banner links on nx.dev / monorepo.tools must themselves include `utm_*` params. That's outside this PR.

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/tito-utm-params-8326d233)
<!-- polygraph-session-end -->