### PR TITLE
feat(conf): embed ti.to widget on /conf/register with UTM passthrough

### DIFF
--- a/apps/website/pages/conf/register.tsx
+++ b/apps/website/pages/conf/register.tsx
@@ -1,0 +1,56 @@
+import { AiConfRegisterPage } from '@monorepo-tools/website/ui-conf';
+import { NextSeo } from 'next-seo';
+import Head from 'next/head';
+import { useRouter } from 'next/router';
+
+export function RegisterPage() {
+  const router = useRouter();
+  const title = 'Register · AI ❤️ Monorepos Conf 2026';
+  const description =
+    'Reserve your free ticket for the AI ❤️ Monorepos Conf 2026. A half-day virtual conference on June 23, 2026.';
+  const image = 'https://monorepo.tools/images/conf/og/conf.png?v=20260604';
+
+  return (
+    <>
+      <NextSeo
+        title={title}
+        description={description}
+        noindex={true}
+        nofollow={true}
+        openGraph={{
+          url: `https://monorepo.tools${router.asPath}`,
+          title,
+          description,
+          images: [
+            {
+              url: image,
+              width: 1200,
+              height: 630,
+              alt: 'AI ❤️ Monorepos Conf 2026',
+              type: 'image/png',
+            },
+          ],
+          site_name: 'monorepo.tools',
+        }}
+        twitter={{
+          handle: '@NxDevTools',
+          site: '@monorepotools',
+          cardType: 'summary_large_image',
+        }}
+      />
+      <Head>
+        <meta key="twitter-title" name="twitter:title" content={title} />
+        <meta
+          key="twitter-description"
+          name="twitter:description"
+          content={description}
+        />
+        <meta key="twitter-image" name="twitter:image" content={image} />
+        <meta key="twitter-image-alt" name="twitter:image:alt" content="AI ❤️ Monorepos Conf 2026" />
+      </Head>
+      <AiConfRegisterPage />
+    </>
+  );
+}
+
+export default RegisterPage;

--- a/libs/website/ui-conf/src/index.ts
+++ b/libs/website/ui-conf/src/index.ts
@@ -1,5 +1,6 @@
 export * from './lib/ai/ai-conf-page';
 export * from './lib/ai/ai-conf-page-badge';
 export * from './lib/ai/ai-conf-speaker-page';
+export * from './lib/ai/ai-conf-register-page';
 export { SPEAKERS } from './lib/ai/data';
 export type { Speaker } from './lib/ai/data';

--- a/libs/website/ui-conf/src/lib/ai/ai-conf-register-page.tsx
+++ b/libs/website/ui-conf/src/lib/ai/ai-conf-register-page.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useState } from 'react';
+import { PALETTE, FONTS, CONF } from './data';
+import { NavBar, ConfFooter } from './shared';
+import { readUtmParams, buildTitoUrl } from './use-register-url';
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      'tito-widget': any;
+    }
+  }
+}
+
+/**
+ * Dedicated registration page hosting the ti.to inline widget with UTM
+ * passthrough. The widget reads utm_* from the page URL and saves them as
+ * registration metadata.
+ * 
+ * On mount:
+ * 1. Reads utm_* from URL or sessionStorage
+ * 2. If utm exist but missing from URL, injects them via history.replaceState
+ * 3. Dynamically loads the ti.to widget script (guards against double-injection)
+ */
+export function AiConfRegisterPage() {
+  const [utm, setUtm] = useState<Record<string, string>>({});
+  const titoUrl = buildTitoUrl(utm);
+
+  useEffect(() => {
+    // Read utm params client-side
+    const params = readUtmParams();
+    setUtm(params);
+
+    // If utm exists but not in current URL, update history to include them
+    const search = new URLSearchParams(window.location.search);
+    const hasUtm = Array.from(search.keys()).some((k) => k.startsWith('utm_'));
+    if (Object.keys(params).length > 0 && !hasUtm) {
+      const newParams = new URLSearchParams(params);
+      const newUrl = `${window.location.pathname}?${newParams.toString()}`;
+      window.history.replaceState(null, '', newUrl);
+    }
+
+    // Dynamically inject the ti.to widget script (guard against double-injection)
+    if (!document.querySelector('script[src*="js.tito.io"]')) {
+      const script = document.createElement('script');
+      script.src = 'https://js.tito.io/v2/with/inline';
+      script.async = true;
+      document.body.appendChild(script);
+    }
+  }, []);
+
+  return (
+    <div
+      style={{
+        width: '100%',
+        background: PALETTE.bg,
+        color: PALETTE.text,
+        fontFamily: FONTS.body,
+        position: 'relative',
+        minHeight: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      <NavBar accent={PALETTE.pink} linkBase="/conf" />
+
+      {/* Hero section */}
+      <div
+        className="mx-auto w-full max-w-[800px] px-5 py-16 md:px-14 md:py-24"
+        style={{
+          textAlign: 'center',
+        }}
+      >
+        <h1
+          style={{
+            fontFamily: FONTS.display,
+            fontSize: 48,
+            fontWeight: 700,
+            letterSpacing: -2,
+            lineHeight: 1.2,
+            marginBottom: 12,
+            color: PALETTE.text,
+          }}
+        >
+          Reserve your free ticket
+        </h1>
+        <p
+          style={{
+            fontFamily: FONTS.body,
+            fontSize: 18,
+            color: PALETTE.textMute,
+            marginBottom: 40,
+          }}
+        >
+          Join us June 23, 2026 for AI ❤️ Monorepos Conf — a half-day virtual
+          conference on agentic AI in monorepos.
+        </p>
+      </div>
+
+      {/* Widget container */}
+      <div
+        className="mx-auto w-full max-w-[640px] px-5 md:px-14"
+        style={{
+          marginBottom: 60,
+          flex: 1,
+        }}
+      >
+        <div
+          style={{
+            background: 'rgba(255,255,255,0.04)',
+            border: `1px solid ${PALETTE.bgLine}`,
+            borderRadius: 8,
+            padding: '32px 24px',
+            backdropFilter: 'blur(8px)',
+          }}
+        >
+          <tito-widget
+            event="nx-conf/2026-ai-monorepos-conf-online"
+            save-metadata-parameters="utm_*"
+          ></tito-widget>
+        </div>
+
+        {/* Fallback link */}
+        <div
+          style={{
+            textAlign: 'center',
+            marginTop: 24,
+          }}
+        >
+          <a
+            href={titoUrl}
+            target="_blank"
+            rel="noreferrer"
+            style={{
+              fontFamily: FONTS.mono,
+              fontSize: 13,
+              color: PALETTE.textMute,
+              textDecoration: 'none',
+              transition: 'color 0.2s',
+            }}
+            onMouseEnter={(e) => {
+              (e.target as HTMLAnchorElement).style.color = PALETTE.cyan;
+            }}
+            onMouseLeave={(e) => {
+              (e.target as HTMLAnchorElement).style.color = PALETTE.textMute;
+            }}
+          >
+            Having trouble? Register on ti.to →
+          </a>
+        </div>
+      </div>
+
+      <ConfFooter accent={PALETTE.pink} linkBase="/conf" />
+    </div>
+  );
+}
+
+export default AiConfRegisterPage;

--- a/libs/website/ui-conf/src/lib/ai/ai-conf-register-page.tsx
+++ b/libs/website/ui-conf/src/lib/ai/ai-conf-register-page.tsx
@@ -1,15 +1,7 @@
-import { useEffect, useState } from 'react';
-import { PALETTE, FONTS, CONF } from './data';
+import { createElement, useEffect, useState } from 'react';
+import { PALETTE, FONTS } from './data';
 import { NavBar, ConfFooter } from './shared';
 import { readUtmParams, buildTitoUrl } from './use-register-url';
-
-declare global {
-  namespace JSX {
-    interface IntrinsicElements {
-      'tito-widget': any;
-    }
-  }
-}
 
 /**
  * Dedicated registration page hosting the ti.to inline widget with UTM
@@ -91,8 +83,12 @@ export function AiConfRegisterPage() {
             marginBottom: 40,
           }}
         >
-          Join us June 23, 2026 for AI ❤️ Monorepos Conf — a half-day virtual
-          conference on agentic AI in monorepos.
+          Join us June 23, 2026 for AI{' '}
+          <span role="img" aria-label="love">
+            ❤️
+          </span>{' '}
+          Monorepos Conf, a half-day virtual conference on agentic AI in
+          monorepos.
         </p>
       </div>
 
@@ -113,10 +109,10 @@ export function AiConfRegisterPage() {
             backdropFilter: 'blur(8px)',
           }}
         >
-          <tito-widget
-            event="nx-conf/2026-ai-monorepos-conf-online"
-            save-metadata-parameters="utm_*"
-          ></tito-widget>
+          {createElement('tito-widget', {
+            event: 'nx-conf/2026-ai-monorepos-conf-online',
+            'save-metadata-parameters': 'utm_*',
+          })}
         </div>
 
         {/* Fallback link */}

--- a/libs/website/ui-conf/src/lib/ai/ai-conf-speaker-page.tsx
+++ b/libs/website/ui-conf/src/lib/ai/ai-conf-speaker-page.tsx
@@ -57,8 +57,6 @@ export function AiConfSpeakerPage({ speaker }: { speaker: Speaker }) {
           <div className="mt-8 flex w-full max-w-[420px] flex-col items-stretch gap-4 sm:w-auto sm:max-w-none sm:flex-row sm:items-center">
             <a
               href={registerUrl}
-              target="_blank"
-              rel="noreferrer"
               className="w-full justify-center sm:w-auto"
               style={{
                 background: PALETTE.pink,

--- a/libs/website/ui-conf/src/lib/ai/badge-hero.tsx
+++ b/libs/website/ui-conf/src/lib/ai/badge-hero.tsx
@@ -705,8 +705,6 @@ export function BadgeHero({ name, role, speaker }: BadgeHeroProps = {}) {
           <div className="mt-8 flex w-full max-w-[360px] flex-col items-stretch gap-4 sm:w-auto sm:max-w-none sm:flex-row sm:items-center">
             <a
               href={registerUrl}
-              target="_blank"
-              rel="noreferrer"
               className="w-full justify-center sm:w-auto"
               style={{
                 background: PALETTE.pink,

--- a/libs/website/ui-conf/src/lib/ai/hero.tsx
+++ b/libs/website/ui-conf/src/lib/ai/hero.tsx
@@ -378,8 +378,6 @@ export function NodeGraphHero() {
         >
           <a
             href={registerUrl}
-            target="_blank"
-            rel="noreferrer"
             className="w-full justify-center sm:w-auto"
             style={{
               background: PALETTE.pink,

--- a/libs/website/ui-conf/src/lib/ai/polygraph-launch.tsx
+++ b/libs/website/ui-conf/src/lib/ai/polygraph-launch.tsx
@@ -61,8 +61,6 @@ export function PolygraphLaunch() {
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
           <a
             href={registerUrl}
-            target="_blank"
-            rel="noreferrer"
             className="justify-center sm:justify-start"
             style={{
               display: 'inline-flex',

--- a/libs/website/ui-conf/src/lib/ai/register-cta.tsx
+++ b/libs/website/ui-conf/src/lib/ai/register-cta.tsx
@@ -46,8 +46,6 @@ export function RegisterCTA() {
         </p>
         <a
           href={registerUrl}
-          target="_blank"
-          rel="noreferrer"
           style={{
             display: 'inline-flex',
             alignItems: 'center',

--- a/libs/website/ui-conf/src/lib/ai/shared.tsx
+++ b/libs/website/ui-conf/src/lib/ai/shared.tsx
@@ -221,8 +221,6 @@ export function NavBar({
           </div>
           <a
             href={registerUrl}
-            target="_blank"
-            rel="noreferrer"
             style={{
               color: PALETTE.bg,
               background: accent,
@@ -882,8 +880,6 @@ export function ConfFooter({
             </a>
             <a
               href={registerUrl}
-              target="_blank"
-              rel="noreferrer"
               style={{ color: PALETTE.textDim, textDecoration: 'none' }}
             >
               Register

--- a/libs/website/ui-conf/src/lib/ai/three-card-hero.tsx
+++ b/libs/website/ui-conf/src/lib/ai/three-card-hero.tsx
@@ -518,8 +518,6 @@ export function ThreeCardHero() {
       >
         <a
           href={registerUrl}
-          target="_blank"
-          rel="noreferrer"
           className="w-full justify-center sm:w-auto"
           style={{
             background: PALETTE.pink,

--- a/libs/website/ui-conf/src/lib/ai/use-register-url.ts
+++ b/libs/website/ui-conf/src/lib/ai/use-register-url.ts
@@ -32,7 +32,41 @@ function persist(params: UtmParams): void {
   }
 }
 
-function withUtm(params: UtmParams): string {
+/**
+ * Shared helper: reads current UTM params from window.location.search and
+ * sessionStorage. Last-touch: a visit carrying utm_* params overwrites the
+ * stored set. Returns the effective UtmParams for the session.
+ * 
+ * Must only be called client-side (checks window.location.search).
+ */
+export function readUtmParams(): UtmParams {
+  const search = new URLSearchParams(window.location.search);
+  const fromUrl: UtmParams = {};
+  for (const key of UTM_KEYS) {
+    const value = search.get(key);
+    if (value) fromUrl[key] = value;
+  }
+
+  const params = Object.keys(fromUrl).length > 0 ? fromUrl : readStored();
+  if (Object.keys(fromUrl).length > 0) persist(fromUrl);
+
+  return params;
+}
+
+/**
+ * Builds the internal /conf/register URL with UTM params appended as query string.
+ * Returns bare "/conf/register" if params are empty.
+ */
+function buildRegisterUrl(params: UtmParams): string {
+  if (Object.keys(params).length === 0) return '/conf/register';
+  return `/conf/register?${new URLSearchParams(params).toString()}`;
+}
+
+/**
+ * Builds the external ti.to URL with UTM params appended.
+ * Used only by the register page fallback link.
+ */
+export function buildTitoUrl(params: UtmParams): string {
   const keys = Object.keys(params);
   if (keys.length === 0) return CONF.registerUrl;
   const url = new URL(CONF.registerUrl);
@@ -41,30 +75,21 @@ function withUtm(params: UtmParams): string {
 }
 
 /**
- * Returns the ti.to registration URL with UTM params carried through from the
+ * Returns the INTERNAL /conf/register URL with UTM params carried through from the
  * /conf landing URL. Captures utm_* from the current URL into sessionStorage so
  * they persist across in-page navigation (speaker modal, speaker sub-page) even
  * though only /conf receives them. Last-touch: a visit carrying utm_* params
  * overwrites the stored set.
  *
- * SSR-safe: renders the bare URL on the server / first client render, then
- * updates after hydration to avoid a markup mismatch.
+ * SSR-safe: renders "/conf/register" on the server / first client render, then
+ * updates after hydration to include utm params to avoid a markup mismatch.
  */
 export function useRegisterUrl(): string {
-  const [url, setUrl] = useState<string>(CONF.registerUrl);
+  const [url, setUrl] = useState<string>('/conf/register');
 
   useEffect(() => {
-    const search = new URLSearchParams(window.location.search);
-    const fromUrl: UtmParams = {};
-    for (const key of UTM_KEYS) {
-      const value = search.get(key);
-      if (value) fromUrl[key] = value;
-    }
-
-    const params = Object.keys(fromUrl).length > 0 ? fromUrl : readStored();
-    if (Object.keys(fromUrl).length > 0) persist(fromUrl);
-
-    setUrl(withUtm(params));
+    const params = readUtmParams();
+    setUrl(buildRegisterUrl(params));
   }, []);
 
   return url;


### PR DESCRIPTION
## Summary

Adds a dedicated `/conf/register` page that embeds the ti.to **inline widget** so signup source (UTM) is actually captured.

### Why

PR #130 appended `utm_*` to outbound ti.to links, but ti.to **strips `utm_*` on its hosted registration page**, so source was never recorded. ti.to only retains UTM when you use their embedded widget with `save-metadata-parameters="utm_*"`, which reads `utm_*` from the **query string of the page hosting the widget** ([Tito Widget V2 docs](https://ti.to/docs/api/widget)). Confirmed by Heidi in Slack.

### What

- **New `/conf/register` page** — renders `<tito-widget event="nx-conf/2026-ai-monorepos-conf-online" save-metadata-parameters="utm_*">` in a light card, with the conf NavBar/footer and a small fallback “register on ti.to” link.
- **All 8 conf register CTAs now route internally** to `/conf/register` carrying `utm_*` (instead of straight to ti.to), so the widget loads with UTM in its URL.
- **`useRegisterUrl` refactored** to build the internal `/conf/register?utm_*` URL; `buildTitoUrl()` added for the fallback link.
- **UTM recovery**: on `/conf/register`, if `utm_*` are missing from the URL but present in `sessionStorage('conf_utm')`, they’re injected via `history.replaceState` **before** the widget script loads (deterministic ordering avoids a race with the async tito loader).
- `/conf/register` is `noindex,nofollow` (funnel page).

Build + lint green.

### How UTM flows

`/conf?utm_source=…` → captured to sessionStorage → CTA → `/conf/register?utm_source=…` → widget reads `utm_*` from URL → saved as registration metadata.

Builds on prior Polygraph session `tito-utm-params-8326d233` (PR #130). Source: Slack thread in #_marketing-internal.

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/test-tito-register-embed-e7d416f3)
<!-- polygraph-session-end -->