### PR TITLE
feat(conf): timezone toggle for schedule + speaker times

### DIFF
--- a/libs/website/ui-conf/src/lib/ai/agenda.tsx
+++ b/libs/website/ui-conf/src/lib/ai/agenda.tsx
@@ -1,6 +1,7 @@
 import type { CSSProperties, MouseEvent } from 'react';
 import { PALETTE, FONTS, SPEAKERS, AGENDA } from './data';
 import { SectionLabel } from './shared';
+import { ScheduleTimezoneBar, SlotTime } from './timezone';
 
 export function Agenda() {
   return (
@@ -10,11 +11,7 @@ export function Agenda() {
       style={{ background: PALETTE.bg }}
     >
       <div className="mx-auto w-full max-w-[1536px] px-5 md:px-20">
-        <SectionLabel
-          index={1}
-          label="Agenda · June 23 · all times PT"
-          accent={PALETTE.pink}
-        />
+        <SectionLabel index={1} label="Agenda" accent={PALETTE.pink} />
         <h2
           className="mb-12 mt-7 text-[40px] tracking-[-1.5px] md:text-[96px] md:tracking-[-3px]"
           style={{
@@ -30,14 +27,25 @@ export function Agenda() {
 
         <div
           style={{
-            fontFamily: FONTS.mono,
-            fontSize: 12,
-            color: PALETTE.pink,
-            letterSpacing: 3,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: 16,
+            flexWrap: 'wrap',
             marginBottom: 24,
           }}
         >
-          SCHEDULE
+          <div
+            style={{
+              fontFamily: FONTS.mono,
+              fontSize: 12,
+              color: PALETTE.pink,
+              letterSpacing: 3,
+            }}
+          >
+            SCHEDULE
+          </div>
+          <ScheduleTimezoneBar />
         </div>
         <div style={{ border: `1px solid ${PALETTE.bgLine}` }}>
           {AGENDA.map((s, i) => {
@@ -46,7 +54,7 @@ export function Agenda() {
             // stay non-clickable.
             const speaker = SPEAKERS.find((sp) => sp.name === s.speaker);
             const rowClass =
-              'grid grid-cols-1 gap-3 md:grid-cols-[150px_1fr_220px] md:items-center md:gap-6';
+              'grid grid-cols-1 gap-3 md:grid-cols-[175px_1fr_220px] md:items-center md:gap-6';
             const rowStyle: CSSProperties = {
               padding: '24px 24px',
               borderBottom:
@@ -73,8 +81,7 @@ export function Agenda() {
                     whiteSpace: 'nowrap',
                   }}
                 >
-                  {s.time}
-                  <span style={{ color: PALETTE.textMute }}> – {s.end}</span>
+                  <SlotTime item={s} showLabel={false} />
                 </div>
                 <div>
                   {s.track !== 'Talk' && (

--- a/libs/website/ui-conf/src/lib/ai/data.ts
+++ b/libs/website/ui-conf/src/lib/ai/data.ts
@@ -38,8 +38,14 @@ export const CONF = {
 };
 
 export type AgendaItem = {
+  // Wall-clock start/end in conference time (PT), kept for the default PT
+  // display so it renders identically without any formatting.
   time: string;
   end: string;
+  // Absolute UTC instants for the slot, the source of truth for converting
+  // into a visitor's local timezone. June 23 2026 is PDT (UTC-7).
+  startISO: string;
+  endISO: string;
   title: string;
   track: string;
   speaker: string;
@@ -50,6 +56,8 @@ export const AGENDA: AgendaItem[] = [
   {
     time: '9:00',
     end: '9:30',
+    startISO: '2026-06-23T16:00:00Z',
+    endISO: '2026-06-23T16:30:00Z',
     title: 'The Infrastructure That Removes the Agent Autonomy Ceiling',
     track: 'Keynote',
     speaker: 'Victor Savkin',
@@ -58,6 +66,8 @@ export const AGENDA: AgendaItem[] = [
   {
     time: '9:30',
     end: '10:00',
+    startISO: '2026-06-23T16:30:00Z',
+    endISO: '2026-06-23T17:00:00Z',
     title: 'The Intersection of Open Source Monorepos and AI w/AnalogJS',
     track: 'Talk',
     speaker: 'Brandon Roberts',
@@ -66,6 +76,8 @@ export const AGENDA: AgendaItem[] = [
   {
     time: '10:00',
     end: '10:30',
+    startISO: '2026-06-23T17:00:00Z',
+    endISO: '2026-06-23T17:30:00Z',
     title: 'How to Run 100 Agents in Parallel',
     track: 'Talk',
     speaker: 'Kiet Ho',
@@ -74,6 +86,8 @@ export const AGENDA: AgendaItem[] = [
   {
     time: '10:30',
     end: '11:00',
+    startISO: '2026-06-23T17:30:00Z',
+    endISO: '2026-06-23T18:00:00Z',
     title: 'Self-Healing CI',
     track: 'Talk',
     speaker: 'James Henry',
@@ -82,6 +96,8 @@ export const AGENDA: AgendaItem[] = [
   {
     time: '11:00',
     end: '11:30',
+    startISO: '2026-06-23T18:00:00Z',
+    endISO: '2026-06-23T18:30:00Z',
     title: "Killing Micro-Frontends: How Radical Simplification 10x'd Our Frontend Velocity",
     track: 'Talk',
     speaker: 'Nicolas Beaussart-Hatchuel',
@@ -90,6 +106,8 @@ export const AGENDA: AgendaItem[] = [
   {
     time: '11:30',
     end: '12:00',
+    startISO: '2026-06-23T18:30:00Z',
+    endISO: '2026-06-23T19:00:00Z',
     title: 'The Last Software Engineer',
     track: 'Talk',
     speaker: 'Kent C. Dodds',
@@ -98,6 +116,8 @@ export const AGENDA: AgendaItem[] = [
   {
     time: '12:00',
     end: '12:30',
+    startISO: '2026-06-23T19:00:00Z',
+    endISO: '2026-06-23T19:30:00Z',
     title: "TanStack's Revolutionary Code Mode AI",
     track: 'Talk',
     speaker: 'Jack Herrington',
@@ -106,6 +126,8 @@ export const AGENDA: AgendaItem[] = [
   {
     time: '12:30',
     end: '1:00',
+    startISO: '2026-06-23T19:30:00Z',
+    endISO: '2026-06-23T20:00:00Z',
     title: "The Agentic Power User's Playbook",
     track: 'Talk',
     speaker: 'John Lindquist',
@@ -114,6 +136,8 @@ export const AGENDA: AgendaItem[] = [
   {
     time: '1:00',
     end: '1:30',
+    startISO: '2026-06-23T20:00:00Z',
+    endISO: '2026-06-23T20:30:00Z',
     title: 'The Missing Paper Trail for Agentic Engineering',
     track: 'Talk',
     speaker: 'Rizèl Scarlett',
@@ -122,6 +146,8 @@ export const AGENDA: AgendaItem[] = [
   {
     time: '1:30',
     end: '2:00',
+    startISO: '2026-06-23T20:30:00Z',
+    endISO: '2026-06-23T21:00:00Z',
     title: 'Your CI Was Already Broken. AI Just Made It Obvious.',
     track: 'Talk',
     speaker: 'Altan Stalker',

--- a/libs/website/ui-conf/src/lib/ai/shared.tsx
+++ b/libs/website/ui-conf/src/lib/ai/shared.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { PALETTE, FONTS, CONF, Speaker, agendaForSpeaker } from './data';
 import { useRegisterUrl } from './use-register-url';
+import { SlotTime } from './timezone';
 
 function useCountdown(targetISO: string) {
   const target = useMemo(() => new Date(targetISO).getTime(), [targetISO]);
@@ -491,7 +492,7 @@ export function TalkBlock({
             }}
           >
             JUN 23 <span style={{ color: PALETTE.textMute }}>·</span>{' '}
-            {slot.time}–{slot.end} PT
+            <SlotTime item={slot} muteColor={PALETTE.textDim} />
           </div>
         )}
       </div>
@@ -707,9 +708,14 @@ export function SpeakerModal({
                   letterSpacing: 2,
                 }}
               >
-                {talk
-                  ? `${talk.track.toUpperCase()} · ${talk.time}–${talk.end} PT`
-                  : `TOPIC · ${speaker.topic.toUpperCase()}`}
+                {talk ? (
+                  <>
+                    {talk.track.toUpperCase()} ·{' '}
+                    <SlotTime item={talk} muteColor={accent} />
+                  </>
+                ) : (
+                  `TOPIC · ${speaker.topic.toUpperCase()}`
+                )}
               </div>
               {talk && (
                 <div
@@ -721,7 +727,7 @@ export function SpeakerModal({
                   }}
                 >
                   JUN 23 <span style={{ color: PALETTE.textMute }}>·</span>{' '}
-                  {talk.time}
+                  <SlotTime item={talk} startOnly muteColor={PALETTE.textMute} />
                 </div>
               )}
             </div>
@@ -752,7 +758,7 @@ export function SpeakerModal({
           </div>
           */}
 
-          <TalkBlock speaker={speaker} accent={accent} />
+          <TalkBlock speaker={speaker} accent={accent} showTime />
 
           <div
             style={{

--- a/libs/website/ui-conf/src/lib/ai/timezone.tsx
+++ b/libs/website/ui-conf/src/lib/ai/timezone.tsx
@@ -1,0 +1,236 @@
+import { useEffect, useState } from 'react';
+import { PALETTE, FONTS, CONF, AgendaItem } from './data';
+
+// Conference timezone. All agenda copy refers to it as "PT".
+const PT_TZ = 'America/Los_Angeles';
+const STORAGE_KEY = 'conf-tz-mode';
+// Custom event so every useTimezone() consumer on the page (and across the
+// speaker routes) stays in sync the moment the toggle is flipped.
+const SYNC_EVENT = 'conf-tz-change';
+
+export type TzMode = 'pt' | 'local';
+
+function getUserTimeZone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || PT_TZ;
+  } catch {
+    return PT_TZ;
+  }
+}
+
+// GMT offset string (e.g. "GMT-7") for a zone at a given instant. Used to
+// decide whether a visitor is effectively already on Pacific time.
+function offsetAt(iso: string, timeZone: string): string {
+  try {
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone,
+      timeZoneName: 'shortOffset',
+    }).formatToParts(new Date(iso));
+    return parts.find((p) => p.type === 'timeZoneName')?.value ?? '';
+  } catch {
+    return '';
+  }
+}
+
+// Short timezone name (e.g. "CEST", or "GMT+2" depending on the engine).
+function abbrevAt(iso: string, timeZone: string): string {
+  try {
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone,
+      timeZoneName: 'short',
+    }).formatToParts(new Date(iso));
+    return parts.find((p) => p.type === 'timeZoneName')?.value ?? '';
+  } catch {
+    return '';
+  }
+}
+
+function isPacific(timeZone: string): boolean {
+  return offsetAt(CONF.targetISO, timeZone) === offsetAt(CONF.targetISO, PT_TZ);
+}
+
+function meridiemParts(iso: string, timeZone: string): { hm: string; mer: string } {
+  const s = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  }).format(new Date(iso));
+  const [hm, mer = ''] = s.split(' ');
+  return { hm, mer };
+}
+
+export type SlotDisplay = { start: string; end: string; label: string };
+
+/** Format a slot's range + timezone label for the active mode. PT mode reuses
+ *  the canonical wall-clock strings so it renders identically to before. */
+export function formatSlot(
+  item: Pick<AgendaItem, 'time' | 'end' | 'startISO' | 'endISO'>,
+  mode: TzMode,
+  userTz: string
+): SlotDisplay {
+  if (mode === 'pt') {
+    return { start: item.time, end: item.end, label: 'PT' };
+  }
+  const a = meridiemParts(item.startISO, userTz);
+  const b = meridiemParts(item.endISO, userTz);
+  // Drop the meridiem on the start when both ends share it ("6:00–6:30 PM").
+  const start = a.mer && a.mer === b.mer ? a.hm : `${a.hm} ${a.mer}`.trim();
+  const end = `${b.hm} ${b.mer}`.trim();
+  return { start, end, label: abbrevAt(item.startISO, userTz) };
+}
+
+/** Client-only timezone preference, persisted to localStorage and synced
+ *  across every consumer via a window event. Defaults to the visitor's local
+ *  timezone (auto-detected); falls back to PT for Pacific visitors. */
+export function useTimezone() {
+  const [mode, setModeState] = useState<TzMode>('pt');
+  const [userTz, setUserTz] = useState(PT_TZ);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    const tz = getUserTimeZone();
+    setUserTz(tz);
+    let stored: TzMode | null = null;
+    try {
+      stored = localStorage.getItem(STORAGE_KEY) as TzMode | null;
+    } catch {
+      stored = null;
+    }
+    setModeState(stored ?? (isPacific(tz) ? 'pt' : 'local'));
+    setMounted(true);
+
+    const sync = () => {
+      try {
+        const m = localStorage.getItem(STORAGE_KEY) as TzMode | null;
+        if (m === 'pt' || m === 'local') setModeState(m);
+      } catch {
+        /* ignore */
+      }
+    };
+    window.addEventListener(SYNC_EVENT, sync);
+    window.addEventListener('storage', sync);
+    return () => {
+      window.removeEventListener(SYNC_EVENT, sync);
+      window.removeEventListener('storage', sync);
+    };
+  }, []);
+
+  const setMode = (m: TzMode) => {
+    setModeState(m);
+    try {
+      localStorage.setItem(STORAGE_KEY, m);
+      window.dispatchEvent(new Event(SYNC_EVENT));
+    } catch {
+      /* ignore */
+    }
+  };
+
+  const localLabel = abbrevAt(CONF.targetISO, userTz);
+  // Hide the toggle for visitors already on Pacific time (nothing to convert).
+  const showToggle = mounted && !isPacific(userTz);
+  return { mode, setMode, userTz, mounted, showToggle, localLabel };
+}
+
+/** Renders a slot's start–end with the active timezone label. Until mounted it
+ *  shows PT so SSR and first paint match. */
+export function SlotTime({
+  item,
+  startOnly = false,
+  showLabel = true,
+  muteColor = PALETTE.textMute,
+}: {
+  item: AgendaItem;
+  startOnly?: boolean;
+  // Omit the timezone label where a surrounding header already states it
+  // (e.g. the agenda list, whose header reads "ALL TIMES <tz>").
+  showLabel?: boolean;
+  muteColor?: string;
+}) {
+  const { mode, userTz, mounted } = useTimezone();
+  const { start, end, label } = formatSlot(item, mounted ? mode : 'pt', userTz);
+  const suffix = showLabel ? ` ${label}` : '';
+  if (startOnly) {
+    return showLabel ? (
+      <>
+        {start} <span style={{ color: muteColor }}>{label}</span>
+      </>
+    ) : (
+      <>{start}</>
+    );
+  }
+  return (
+    <>
+      {start}
+      <span style={{ color: muteColor }}>
+        {' '}
+        – {end}
+        {suffix}
+      </span>
+    </>
+  );
+}
+
+/** The "JUNE 23 · ALL TIMES PT" line plus the PT / local toggle, designed to
+ *  sit on the schedule header row. */
+export function ScheduleTimezoneBar() {
+  const { mode, setMode, mounted, showToggle, localLabel } = useTimezone();
+  const activeLabel = mounted && mode === 'local' ? localLabel : 'PT';
+
+  const tab = (m: TzMode, text: string) => {
+    const active = mode === m;
+    return (
+      <button
+        key={m}
+        type="button"
+        onClick={() => setMode(m)}
+        style={{
+          fontFamily: FONTS.mono,
+          fontSize: 11,
+          letterSpacing: 1,
+          padding: '4px 10px',
+          border: 'none',
+          cursor: 'pointer',
+          background: active ? 'rgba(245,158,11,0.12)' : 'transparent',
+          color: active ? PALETTE.pink : PALETTE.textMute,
+          transition: 'color 0.15s, background 0.15s',
+        }}
+      >
+        {text}
+      </button>
+    );
+  };
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        flexWrap: 'wrap',
+      }}
+    >
+      <span
+        style={{
+          fontFamily: FONTS.mono,
+          fontSize: 12,
+          color: PALETTE.pink,
+          letterSpacing: 3,
+        }}
+      >
+        JUNE 23 · ALL TIMES {activeLabel}
+      </span>
+      {showToggle && (
+        <span
+          style={{
+            display: 'inline-flex',
+            border: `1px solid ${PALETTE.bgLine}`,
+          }}
+        >
+          {tab('pt', 'PT')}
+          {tab('local', localLabel || 'LOCAL')}
+        </span>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Detects the visitor's browser timezone and converts all conference times, with a **PT / local** toggle on the schedule header.

- Each agenda slot is anchored to a UTC instant (`startISO`/`endISO`) as the source of truth; PT display reuses the existing wall-clock strings, so PT mode renders identically to before.
- New `timezone.tsx`: `useTimezone` hook (auto-detects local tz, persists to `localStorage`, syncs across the page and speaker routes), plus `formatSlot`, `SlotTime`, and `ScheduleTimezoneBar` (the relocated "JUNE 23 · ALL TIMES …" label + toggle). No new dependencies — uses the native `Intl` API.
- Schedule header now hosts the label + toggle; agenda rows show bare converted times (header states the zone). The speaker modal and standalone `/conf/speaker/[id]` page show the converted time **with** the zone label.
- Defaults to the visitor's local timezone (auto-detected); Pacific visitors get no toggle. SSR renders PT to avoid hydration mismatch.

> Note: the tz abbreviation is engine-dependent (Chrome → `GMT+2`, Safari → `CEST`). Can be normalized via a lookup table if we want consistent labels.

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/schedule-timezones-578a0fbf)
<!-- polygraph-session-end -->