### PR TITLE
fix(conf): keep ti.to register form readable in OS dark mode

### DIFF
--- a/apps/website/pages/styles.css
+++ b/apps/website/pages/styles.css
@@ -29,3 +29,12 @@ main > div[id].pt-16 {
     background-color: hsl(217.2, 32.6%, 17.5%);
   }
 }
+
+/* The ti.to inline widget + checkout overlay (registration form) are light-themed:
+   white fields with dark (#333) input text. Under OS dark mode the browser paints
+   form controls with a dark UA background, leaving dark text on dark = invisible.
+   Pin tito's UI to a light color-scheme so its fields stay readable. */
+tito-widget,
+#tito-overlay {
+  color-scheme: light;
+}


### PR DESCRIPTION
## Summary

The ti.to signup form on `/conf/register` rendered with invisible input text in OS dark mode.

**Root cause:** the ti.to checkout form is light-themed — it hardcodes dark `#333` input text expecting white fields. Under OS dark mode the document's `color-scheme` resolves to `dark`, so the browser painted ti.to's form controls with a dark UA background (`#3b3b3b`). Dark `#333` text on a `#3b3b3b` field = invisible.

**Fix:** pin ti.to's widget + checkout overlay to a light `color-scheme` in the global stylesheet so the fields keep white backgrounds matching ti.to's dark text. Global CSS is required because the checkout modal (`#tito-overlay`) is appended to `body`, outside the React tree.

```css
tito-widget,
#tito-overlay {
  color-scheme: light;
}
```

Verified live with agent-browser: computed input styles were `#333` on `#3b3b3b` before, white field with readable dark text after.

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/fix-tito-signup-style-1171e549)
<!-- polygraph-session-end -->