### PR TITLE
feat(conf): show Watch Live banner on speaker pages

### DIFF
--- a/libs/website/ui-conf/src/lib/ai/ai-conf-speaker-page.tsx
+++ b/libs/website/ui-conf/src/lib/ai/ai-conf-speaker-page.tsx
@@ -11,6 +11,7 @@ import { Stat } from './hero';
 import { BadgeStage, speakerBadgeContent } from './badge-hero';
 import { Hosts } from './hosts';
 import { RegisterCTA } from './register-cta';
+import { LiveBanner } from './live-banner';
 
 /**
  * Dedicated, deep-linkable page for a single speaker. Reuses the conf
@@ -35,6 +36,7 @@ export function AiConfSpeakerPage({ speaker }: { speaker: Speaker }) {
         @keyframes aiconfMarquee { from { transform: translateX(0); } to { transform: translateX(-50%); } }
       `}</style>
       <NavBar accent={PALETTE.pink} linkBase="/conf" />
+      <LiveBanner />
 
       {/* hero: talk details + speaker badge, centered as a group */}
       <div


### PR DESCRIPTION
Speaker subpages were missing the top "Watch Live" banner that the main conf landing page shows. This adds the `LiveBanner` to `ai-conf-speaker-page.tsx`, rendered right after `NavBar` exactly as on the landing page.

The banner self-gates on `LIVE.isLive` in `data.ts`, so it only appears while the stream is live.

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/vivid-beaver-cf29611f)
<!-- polygraph-session-end -->