### PR TITLE
feat(conf): switch conf + Polygraph CTAs to post-event state

### DIFF
--- a/libs/website/ui-commons/src/lib/hero.tsx
+++ b/libs/website/ui-commons/src/lib/hero.tsx
@@ -58,7 +58,7 @@ export function Hero() {
                 </div>
               </div>
               <span className="hidden whitespace-nowrap rounded-md border border-amber-500 px-3 py-2 text-sm font-medium text-amber-600 transition-colors group-hover:bg-amber-500 group-hover:text-white sm:inline-block dark:text-amber-400">
-                Register free →
+                Watch the recording →
               </span>
             </a>
           </div>

--- a/libs/website/ui-conf/src/lib/ai/ai-conf-page-badge.tsx
+++ b/libs/website/ui-conf/src/lib/ai/ai-conf-page-badge.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { PALETTE, FONTS, Speaker, SPEAKERS } from './data';
-import { CountdownPill, NavBar, SpeakerModal, ConfFooter } from './shared';
+import { NavBar, SpeakerModal, ConfFooter } from './shared';
 import { Stat } from './hero';
 import { BadgeHero } from './badge-hero';
 import { Agenda } from './agenda';
@@ -83,19 +83,16 @@ export function AiConfPageBadge() {
             background: PALETTE.bgDeeper,
           }}
         >
-          <div className="mx-auto grid w-full max-w-[1536px] grid-cols-1 items-center gap-8 px-5 md:grid-cols-3 md:px-14">
+          <div className="mx-auto grid w-full max-w-[1536px] grid-cols-1 items-center gap-8 px-5 md:grid-cols-2 md:px-14">
             <Stat label="DATE" value="June 23, 2026" tone={PALETTE.pink} />
-            <div className="md:justify-self-center">
-              <Stat label="FORMAT" value="Online, free" tone={PALETTE.cyan} />
-            </div>
             <div className="md:justify-self-end">
-              <CountdownPill compact />
+              <Stat label="FORMAT" value="Online, free" tone={PALETTE.cyan} />
             </div>
           </div>
         </div>
       </div>
-      <Agenda />
       <PolygraphLaunch />
+      <Agenda />
       <SpeakerGrid onPick={setModalSpeaker} />
       <Hosts />
       <RegisterCTA />

--- a/libs/website/ui-conf/src/lib/ai/ai-conf-page.tsx
+++ b/libs/website/ui-conf/src/lib/ai/ai-conf-page.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { PALETTE, FONTS, Speaker, SPEAKERS } from './data';
-import { CountdownPill, NavBar, SpeakerModal, ConfFooter } from './shared';
+import { NavBar, SpeakerModal, ConfFooter } from './shared';
 import { Stat } from './hero';
 import { ThreeCardHero } from './three-card-hero';
 import { Agenda } from './agenda';
@@ -44,7 +44,7 @@ export function AiConfPage() {
       <LiveBanner />
       <ThreeCardHero />
       <div
-        className="grid grid-cols-1 items-center gap-8 px-5 py-8 md:grid-cols-3 md:px-14 md:py-10"
+        className="grid grid-cols-1 items-center gap-8 px-5 py-8 md:grid-cols-2 md:px-14 md:py-10"
         style={{
           borderTop: `1px solid ${PALETTE.bgLine}`,
           borderBottom: `1px solid ${PALETTE.bgLine}`,
@@ -52,11 +52,8 @@ export function AiConfPage() {
         }}
       >
         <Stat label="DATE" value="June 23, 2026" tone={PALETTE.pink} />
-        <div className="md:justify-self-center">
-          <Stat label="FORMAT" value="Online, free" tone={PALETTE.cyan} />
-        </div>
         <div className="md:justify-self-end">
-          <CountdownPill compact />
+          <Stat label="FORMAT" value="Online, free" tone={PALETTE.cyan} />
         </div>
       </div>
       <Agenda />

--- a/libs/website/ui-conf/src/lib/ai/ai-conf-speaker-page.tsx
+++ b/libs/website/ui-conf/src/lib/ai/ai-conf-speaker-page.tsx
@@ -1,12 +1,6 @@
 import { PALETTE, FONTS, Speaker } from './data';
 import { useRegisterUrl } from './use-register-url';
-import {
-  CountdownPill,
-  NavBar,
-  ConfFooter,
-  TalkBlock,
-  SpeakerLinks,
-} from './shared';
+import { NavBar, ConfFooter, TalkBlock, SpeakerLinks } from './shared';
 import { Stat } from './hero';
 import { BadgeStage, speakerBadgeContent } from './badge-hero';
 import { Hosts } from './hosts';
@@ -109,7 +103,7 @@ export function AiConfSpeakerPage({ speaker }: { speaker: Speaker }) {
 
       {/* conf info bar */}
       <div
-        className="grid grid-cols-1 items-center gap-8 px-5 py-8 md:grid-cols-3 md:px-14 md:py-10"
+        className="grid grid-cols-1 items-center gap-8 px-5 py-8 md:grid-cols-2 md:px-14 md:py-10"
         style={{
           borderTop: `1px solid ${PALETTE.bgLine}`,
           borderBottom: `1px solid ${PALETTE.bgLine}`,
@@ -117,11 +111,8 @@ export function AiConfSpeakerPage({ speaker }: { speaker: Speaker }) {
         }}
       >
         <Stat label="DATE" value="June 23, 2026" tone={PALETTE.pink} />
-        <div className="md:justify-self-center">
-          <Stat label="FORMAT" value="Online, free" tone={PALETTE.cyan} />
-        </div>
         <div className="md:justify-self-end">
-          <CountdownPill compact />
+          <Stat label="FORMAT" value="Online, free" tone={PALETTE.cyan} />
         </div>
       </div>
 

--- a/libs/website/ui-conf/src/lib/ai/data.ts
+++ b/libs/website/ui-conf/src/lib/ai/data.ts
@@ -162,10 +162,14 @@ export function agendaForSpeaker(name: string): AgendaItem | undefined {
 }
 
 // ---- Live stream ----------------------------------------------------------
-// Drives the live banner + watch pill on /conf. Flip `isLive` off after the
-// event to retire both. The CTAs open the YouTube live stream directly.
+// Drives the stream banner + nav CTA on /conf via a lifecycle `phase`:
+//   'live'  → red "LIVE NOW" banner, "Join the live stream" CTA
+//   'ended' → recap banner, "Catch up with the recording" CTA (the live URL
+//             becomes the YouTube VOD once the stream ends)
+//   'off'   → no banner; the nav "Register →" button returns
+// Flip `phase` as the event progresses. `watchUrl` is reused across states.
 export const LIVE = {
-  isLive: true,
+  phase: 'ended' as 'live' | 'ended' | 'off',
   watchUrl: 'https://youtube.com/live/y8H-LeWQxlQ',
   // Red reads as "live" everywhere; kept distinct from the amber accent so the
   // LIVE state stays unmistakable against the rest of the conf palette.

--- a/libs/website/ui-conf/src/lib/ai/hosts.tsx
+++ b/libs/website/ui-conf/src/lib/ai/hosts.tsx
@@ -75,7 +75,7 @@ export function Hosts() {
             style={{ width: 1, height: 80, background: PALETTE.bgLine }}
           />
           <a
-            href="https://trypolygraph.com"
+            href="https://trypolygraph.com?utm_source=monorepo.tools&utm_medium=referral&utm_campaign=ai-conf-2026&utm_content=hosts-logo"
             target="_blank"
             rel="noreferrer"
             style={{

--- a/libs/website/ui-conf/src/lib/ai/live-banner.tsx
+++ b/libs/website/ui-conf/src/lib/ai/live-banner.tsx
@@ -30,13 +30,14 @@ export const LIVE_KEYFRAMES = `
 `;
 
 /**
- * Sticky strip under the conf nav announcing that the stream is live, with a
- * CTA that opens the YouTube live stream in a new tab. Deliberately doesn't name
- * the current talk; the running order can shift live and we don't track it.
- * Renders nothing when not live.
+ * Strip under the conf nav, shown only while the stream is live. The recap
+ * ('ended') and retired ('off') phases render nothing here — the post-event
+ * "catch up with the recording" CTA lives in the nav instead. The live state
+ * deliberately doesn't name the current talk; the running order can shift
+ * live and we don't track it.
  */
 export function LiveBanner() {
-  if (!LIVE.isLive) return null;
+  if (LIVE.phase !== 'live') return null;
 
   return (
     <>

--- a/libs/website/ui-conf/src/lib/ai/polygraph-launch.tsx
+++ b/libs/website/ui-conf/src/lib/ai/polygraph-launch.tsx
@@ -1,21 +1,10 @@
-import { useEffect, useState } from 'react';
 import { PALETTE, FONTS } from './data';
 
-const TRAILER_EMBED =
-  'https://www.youtube.com/embed/6xvOrf4U4zM?autoplay=1&rel=0';
+// Inline (non-autoplay) embed — the trailer now lives on the page rather than
+// behind a modal, so it should sit idle until the visitor hits play.
+const TRAILER_EMBED = 'https://www.youtube.com/embed/6xvOrf4U4zM?rel=0';
 
 export function PolygraphLaunch() {
-  const [trailerOpen, setTrailerOpen] = useState(false);
-
-  useEffect(() => {
-    if (!trailerOpen) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setTrailerOpen(false);
-    };
-    document.addEventListener('keydown', onKey);
-    return () => document.removeEventListener('keydown', onKey);
-  }, [trailerOpen]);
-
   return (
     <div
       id="polygraph-launch"
@@ -23,57 +12,59 @@ export function PolygraphLaunch() {
       style={{
         background: PALETTE.bgDeeper,
         borderTop: `1px solid ${PALETTE.bgLine}`,
+        borderBottom: `1px solid ${PALETTE.bgLine}`,
       }}
     >
       <div
-        className="px-6 py-10 md:px-12 md:py-12"
+        className="mx-auto grid grid-cols-1 items-center gap-10 px-6 py-10 md:grid-cols-2 md:gap-12 md:px-12 md:py-12"
         style={{
           border: `1px solid ${PALETTE.bgLine}`,
           background: 'rgba(245,158,11,0.03)',
-          maxWidth: 760,
-          margin: '0 auto',
+          maxWidth: 1180,
         }}
       >
-        <div className="flex items-center gap-4" style={{ marginBottom: 20 }}>
-          <img
-            src="/images/conf/polygraph-logo.svg"
-            alt="Polygraph"
-            style={{ height: 30, width: 'auto' }}
-          />
-          <span
-            className="text-[16px] md:text-[18px]"
+        {/* left: copy + CTA */}
+        <div>
+          <div className="flex items-center gap-4" style={{ marginBottom: 20 }}>
+            <img
+              src="/images/conf/polygraph-logo.svg"
+              alt="Polygraph"
+              style={{ height: 30, width: 'auto' }}
+            />
+            <span
+              className="text-[16px] md:text-[18px]"
+              style={{
+                fontFamily: FONTS.mono,
+                color: PALETTE.pink,
+                letterSpacing: 2,
+                fontWeight: 600,
+              }}
+            >
+              LIVE LAUNCH
+            </span>
+          </div>
+
+          <p
+            className="text-[15px] md:text-[17px]"
             style={{
-              fontFamily: FONTS.mono,
-              color: PALETTE.pink,
-              letterSpacing: 2,
-              fontWeight: 600,
+              fontFamily: FONTS.body,
+              color: PALETTE.textDim,
+              lineHeight: 1.6,
+              maxWidth: 580,
+              margin: '0 0 28px',
             }}
           >
-            LIVE LAUNCH
-          </span>
-        </div>
+            <strong style={{ color: PALETTE.text, fontWeight: 700 }}>
+              Jeff Cross and Victor Savkin launched Polygraph.
+            </strong>{' '}
+            A meta-harness that gives your AI coding agents autonomy across
+            repository and session boundaries. It works alongside the agents you
+            already use, coordinating changes across repos and keeping a
+            persistent memory of their work.
+          </p>
 
-        <p
-          className="text-[15px] md:text-[17px]"
-          style={{
-            fontFamily: FONTS.body,
-            color: PALETTE.textDim,
-            lineHeight: 1.6,
-            maxWidth: 580,
-            margin: '0 0 28px',
-          }}
-        >
-          <strong style={{ color: PALETTE.text, fontWeight: 700 }}>
-            Jeff Cross and Victor Savkin are launching Polygraph live.
-          </strong>{' '}
-          A platform enabling agentic collaboration across sessions and
-          repository boundaries. Catch the announcement at the conf, or get
-          Polygraph now.
-        </p>
-
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
           <a
-            href="https://trypolygraph.com"
+            href="https://trypolygraph.com?utm_source=monorepo.tools&utm_medium=referral&utm_campaign=ai-conf-2026&utm_content=launch-cta"
             target="_blank"
             rel="noreferrer"
             className="justify-center sm:justify-start"
@@ -91,96 +82,35 @@ export function PolygraphLaunch() {
               textDecoration: 'none',
             }}
           >
-            GET POLYGRAPH NOW →
+            TRY POLYGRAPH NOW →
           </a>
-          <button
-            type="button"
-            onClick={() => setTrailerOpen(true)}
-            className="justify-center sm:justify-start"
-            style={{
-              display: 'inline-flex',
-              alignItems: 'center',
-              gap: 10,
-              color: PALETTE.text,
-              padding: '14px 24px',
-              fontFamily: FONTS.mono,
-              fontSize: 13,
-              letterSpacing: 1,
-              background: 'transparent',
-              cursor: 'pointer',
-              border: `1px solid ${PALETTE.textDim}`,
-            }}
-          >
-            WATCH THE TRAILER →
-          </button>
         </div>
-      </div>
 
-      {trailerOpen && (
+        {/* right: embedded trailer (16:9) */}
         <div
-          role="dialog"
-          aria-modal="true"
-          aria-label="Polygraph trailer"
-          onClick={() => setTrailerOpen(false)}
           style={{
-            position: 'fixed',
-            inset: 0,
-            zIndex: 50,
-            background: 'rgba(15,23,42,0.85)',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            padding: 20,
+            position: 'relative',
+            width: '100%',
+            paddingTop: '56.25%',
+            background: '#000',
+            border: `1px solid ${PALETTE.bgLine}`,
           }}
         >
-          <div
-            onClick={(e) => e.stopPropagation()}
-            style={{ width: '100%', maxWidth: 960 }}
-          >
-            <div className="flex justify-end" style={{ marginBottom: 12 }}>
-              <button
-                type="button"
-                onClick={() => setTrailerOpen(false)}
-                aria-label="Close trailer"
-                style={{
-                  color: PALETTE.text,
-                  background: 'transparent',
-                  border: `1px solid ${PALETTE.textDim}`,
-                  width: 36,
-                  height: 36,
-                  fontSize: 18,
-                  lineHeight: 1,
-                  cursor: 'pointer',
-                }}
-              >
-                ✕
-              </button>
-            </div>
-            <div
-              style={{
-                position: 'relative',
-                width: '100%',
-                paddingTop: '56.25%',
-                background: '#000',
-              }}
-            >
-              <iframe
-                src={TRAILER_EMBED}
-                title="Polygraph trailer"
-                allow="autoplay; encrypted-media; picture-in-picture; fullscreen"
-                allowFullScreen
-                style={{
-                  position: 'absolute',
-                  inset: 0,
-                  width: '100%',
-                  height: '100%',
-                  border: 0,
-                }}
-              />
-            </div>
-          </div>
+          <iframe
+            src={TRAILER_EMBED}
+            title="Polygraph trailer"
+            allow="encrypted-media; picture-in-picture; fullscreen"
+            allowFullScreen
+            style={{
+              position: 'absolute',
+              inset: 0,
+              width: '100%',
+              height: '100%',
+              border: 0,
+            }}
+          />
         </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/libs/website/ui-conf/src/lib/ai/shared.tsx
+++ b/libs/website/ui-conf/src/lib/ai/shared.tsx
@@ -226,7 +226,26 @@ export function NavBar({
               Code of Conduct
             </a>
           </div>
-          {!LIVE.isLive && (
+          {/* Post-event: the recording CTA lives in the nav (no separate
+              banner). Pre-event: Register. While live: nothing — the red live
+              banner under the nav carries that CTA. */}
+          {LIVE.phase === 'ended' ? (
+            <a
+              href={LIVE.watchUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{
+                color: PALETTE.bg,
+                background: accent,
+                padding: '10px 18px',
+                textDecoration: 'none',
+                fontWeight: 600,
+                letterSpacing: 0.5,
+              }}
+            >
+              Watch the recording →
+            </a>
+          ) : LIVE.phase === 'off' ? (
             <a
               href={registerUrl}
               style={{
@@ -240,7 +259,7 @@ export function NavBar({
             >
               Register →
             </a>
-          )}
+          ) : null}
         </div>
       </div>
     </nav>
@@ -918,7 +937,7 @@ export function ConfFooter({
               Nx → nx.dev
             </a>
             <a
-              href="https://trypolygraph.com"
+              href="https://trypolygraph.com?utm_source=monorepo.tools&utm_medium=referral&utm_campaign=ai-conf-2026&utm_content=footer"
               style={{ color: PALETTE.textDim, textDecoration: 'none' }}
             >
               Polygraph → trypolygraph.com

--- a/libs/website/ui-synthetic-monorepos/src/lib/featured-webinar.tsx
+++ b/libs/website/ui-synthetic-monorepos/src/lib/featured-webinar.tsx
@@ -61,7 +61,7 @@ export function FeaturedWebinar(): JSX.Element {
 
           <div className="flex flex-col rounded-lg border border-slate-200 bg-slate-50 p-6 shadow-sm sm:p-8 dark:border-slate-700 dark:bg-slate-800">
             <p className="text-xs font-semibold uppercase tracking-[1.5px] text-yellow-600 dark:text-yellow-500">
-              Early Access
+              Now Available
             </p>
             <div className="mt-3 flex items-start gap-4 lg:min-h-[7rem]">
               <img
@@ -82,16 +82,16 @@ export function FeaturedWebinar(): JSX.Element {
 
             <div className="mt-auto border-t border-slate-200 pt-5 dark:border-slate-700">
               <p className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                Now in early access
+                Available now
               </p>
               <div className="mt-3">
                 <a
-                  href="https://trypolygraph.com/#form"
+                  href="https://trypolygraph.com?utm_source=monorepo.tools&utm_medium=referral&utm_campaign=synthetic-monorepos&utm_content=featured-card"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="inline-flex items-center rounded-md bg-gray-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-gray-800 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
                 >
-                  Get early access
+                  Try Polygraph now
                 </a>
               </div>
             </div>


### PR DESCRIPTION
## Summary

Updates the conference site and related Polygraph CTAs from pre/live-event state to a post-event "recording is up" state now that AI ❤️ Monorepos Conf 2026 (June 23, 2026) has wrapped.

- **Conf `/conf`**: retired the live "Join the live stream" banner; nav now shows **Watch the recording →** when the event has ended, driven by a new `LIVE.phase` lifecycle (`live` / `ended` / `off`) in `data.ts`. Removed the "STARTS IN" countdown; the meta strip is now DATE (left) / FORMAT "Online, free" (right).
- **Conf launch block**: moved above the schedule for visibility, made two-column with the Polygraph trailer embedded inline (modal removed), CTA **TRY POLYGRAPH NOW →**, and copy rewritten to past tense ("Jeff Cross and Victor Savkin launched Polygraph. A meta-harness that gives your AI coding agents autonomy across repository and session boundaries…").
- **Synthetic Monorepos page**: dropped the early-access framing — eyebrow **NOW AVAILABLE**, status **Available now**, button **Try Polygraph now**.
- **Home**: conf banner CTA changed from "Register free" to **Watch the recording**.
- **UTM**: added `utm_source`/`utm_medium`/`utm_campaign`/`utm_content` tags to all `trypolygraph.com` links (campaigns `ai-conf-2026` and `synthetic-monorepos`).

Lint passes on all touched projects (0 errors). Verified visually via dev server on `/conf`, `/`, and `/synthetic-monorepos`.

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/fair-cheetah-dbc5810c)
<!-- polygraph-session-end -->